### PR TITLE
feat: add infrastructure for SRE Agent with App Service and Chaos Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,97 @@
 
 Repo to consolidate Azure SRE Agent demos and resources
 
+## Infrastructure Deployment
+
+This repository includes Bicep Infrastructure as Code (IaC) to deploy the complete SRE Agent demo environment, including:
+
+- **Azure App Service** with deployment slots for failure simulation
+- **Azure Chaos Studio** for chaos engineering experiments
+- **Application Insights** for monitoring
+- **Log Analytics Workspace** for diagnostics
+
+### Quick Deployment
+
+```bash
+# Login to Azure
+az login --tenant <yourtenant>
+
+# Deploy the infrastructure (subscription-level deployment)
+az deployment sub create \
+  --name sre-agent-demo-resources \
+  --location eastus2 \
+  --template-file infra/main.bicep \
+  --parameters infra/main.parameters.json
+```
+
+### Customizing Deployment
+
+Edit `infra/main.parameters.json` to customize:
+
+| Parameter                   | Description              | Default             |
+| --------------------------- | ------------------------ | ------------------- |
+| `namePrefix`                | Prefix for all resources | `sreagent`          |
+| `location`                  | Azure region             | `swedencentral`     |
+| `resourceGroupName`         | Resource group name      | `rg-sre-agent-demo` |
+| `appServiceSkuName`         | App Service Plan SKU     | `S1`                |
+| `runtimeStack`              | Web app runtime          | `DOTNETCORE\|9.0`   |
+| `enableChaosStudio`         | Deploy Chaos Studio      | `true`              |
+| `enableApplicationInsights` | Enable App Insights      | `true`              |
+
+### Azure Verified Modules (AVM)
+
+This infrastructure uses [Azure Verified Modules](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res) where available:
+
+- `avm/res/web/serverfarm` - App Service Plan
+- `avm/res/web/site` - Web App
+- `avm/res/operational-insights/workspace` - Log Analytics
+
+### SRE Agent Setup
+
+> **Note**: Azure SRE Agent is currently in Preview and must be configured via the Azure Portal.
+
+After deploying the infrastructure:
+
+1. Navigate to the [Azure Portal](https://portal.azure.com)
+2. Search for **"Azure SRE Agent"** in the search bar
+3. Select **"+ Create"** to create a new agent
+4. Configure the agent:
+   - **Subscription**: Your Azure subscription
+   - **Resource Group**: Create new (e.g., `rg-sre-agent`)
+   - **Name**: `my-sre-agent`
+   - **Region**: East US 2 (or available region)
+5. Select **"Select resource groups"** and choose the resource group containing your App Service
+6. Click **"Create"**
+
+For detailed setup instructions, see [Tutorial: Troubleshoot an App Service app using Azure SRE Agent](https://learn.microsoft.com/en-us/azure/sre-agent/troubleshoot-azure-app-service)
+
+### Testing the Demo
+
+1. **Verify the app is running**:
+
+   - Open the Web App URL (from deployment outputs)
+   - Click the "Increment" button several times
+
+2. **Simulate a failure**:
+
+   - In the Azure Portal, navigate to your App Service
+   - Go to **Deployment > Deployment slots**
+   - Click **Swap** to swap the `broken` slot to production
+   - The app now has error injection enabled
+
+3. **Let SRE Agent diagnose**:
+
+   - Open SRE Agent in the Azure Portal
+   - Chat: "What's wrong with my-sre-app?"
+   - The agent will analyze and propose remediation (slot swap rollback)
+
+4. **Run Chaos Experiment** (optional):
+   - Navigate to **Chaos Studio > Experiments**
+   - Select the chaos experiment
+   - Click **Start** to test App Service resilience
+
+---
+
 ## Development Environment
 
 This repository includes a fully configured devcontainer for Azure development with SRE Agent tooling.
@@ -20,6 +111,7 @@ This repository includes a fully configured devcontainer for Azure development w
 3. When prompted, click "Reopen in Container" or run the command `Dev Containers: Reopen in Container`
 4. Wait for the container to build and initialize
 5. Authenticate with Azure:
+
    ```bash
    az login
    azd auth login
@@ -27,16 +119,16 @@ This repository includes a fully configured devcontainer for Azure development w
 
 ### Included Tools
 
-| Tool | Description |
-|------|-------------|
-| **Azure CLI** | Command-line interface for Azure with Bicep support |
+| Tool                          | Description                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| **Azure CLI**                 | Command-line interface for Azure with Bicep support           |
 | **Azure Developer CLI (azd)** | Developer-focused Azure tooling for templates and deployments |
-| **Bicep** | Domain-specific language for deploying Azure resources |
-| **Azure MCP Server** | Model Context Protocol server for agentic Azure workflows |
-| **Node.js** | JavaScript runtime for development |
-| **Python 3.12** | Python interpreter for scripting and automation |
-| **Docker-in-Docker** | Container runtime for local development |
-| **GitHub CLI** | GitHub command-line interface |
+| **Bicep**                     | Domain-specific language for deploying Azure resources        |
+| **Azure MCP Server**          | Model Context Protocol server for agentic Azure workflows     |
+| **Node.js**                   | JavaScript runtime for development                            |
+| **Python 3.12**               | Python interpreter for scripting and automation               |
+| **Docker-in-Docker**          | Container runtime for local development                       |
+| **GitHub CLI**                | GitHub command-line interface                                 |
 
 ### Azure CLI Extensions
 
@@ -71,6 +163,7 @@ The repository includes pre-configured MCP servers in `.vscode/mcp.json`:
 - **Microsoft Learn MCP Server**: Access official Microsoft documentation and code samples
 
 To use MCP with GitHub Copilot:
+
 1. Open Copilot Chat in VS Code
 2. Switch to Agent Mode
 3. The MCP servers will automatically connect

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,171 @@
+// Main Bicep deployment for SRE Agent Demo
+// Deploys App Service, Chaos Studio, and supporting infrastructure
+
+targetScope = 'subscription'
+
+@description('Required. Name prefix for all resources.')
+@minLength(3)
+@maxLength(10)
+param namePrefix string
+
+@description('Required. Azure region for deployment.')
+param location string
+
+@description('Optional. Name of the resource group.')
+param resourceGroupName string = 'rg-${namePrefix}-sre-agent'
+
+@description('Optional. Tags to apply to all resources.')
+param tags object = {}
+
+@description('Optional. The SKU name for the App Service Plan.')
+@allowed([
+  'F1'
+  'B1'
+  'B2'
+  'B3'
+  'S1'
+  'S2'
+  'S3'
+  'P1v3'
+  'P2v3'
+  'P3v3'
+])
+param appServiceSkuName string = 'S1'
+
+@description('Optional. The runtime stack for the web app.')
+@allowed([
+  'DOTNETCORE|9.0'
+  'DOTNETCORE|8.0'
+  'NODE|20-lts'
+  'NODE|18-lts'
+  'PYTHON|3.12'
+  'PYTHON|3.11'
+])
+param runtimeStack string = 'DOTNETCORE|9.0'
+
+@description('Optional. External Git repository URL for deployment.')
+param externalGitRepoUrl string = 'https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial'
+
+@description('Optional. Branch of the external Git repository.')
+param externalGitBranch string = 'main'
+
+@description('Optional. Enable Application Insights.')
+param enableApplicationInsights bool = true
+
+@description('Optional. Enable Chaos Studio experiment.')
+param enableChaosStudio bool = true
+
+@description('Optional. Duration of the chaos experiment (ISO 8601 format).')
+param chaosExperimentDuration string = 'PT10M'
+
+@description('Optional. Deploy Log Analytics workspace for monitoring.')
+param deployLogAnalytics bool = true
+
+// Variables
+var logAnalyticsName = 'log-${namePrefix}'
+
+// Resource Group
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+  tags: union(tags, {
+    'sre-agent-demo': 'true'
+    'deployed-by': 'bicep'
+  })
+}
+
+// Log Analytics Workspace (for Application Insights and diagnostics)
+module logAnalytics 'br/public:avm/res/operational-insights/workspace:0.9.1' = if (deployLogAnalytics) {
+  scope: rg
+  name: '${uniqueString(deployment().name, location)}-law'
+  params: {
+    name: logAnalyticsName
+    location: location
+    tags: tags
+    skuName: 'PerGB2018'
+    dataRetention: 30
+  }
+}
+
+// App Service Module
+module appService 'modules/app-service.bicep' = {
+  scope: rg
+  name: '${uniqueString(deployment().name, location)}-appservice'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    tags: tags
+    skuName: appServiceSkuName
+    runtimeStack: runtimeStack
+    externalGitRepoUrl: externalGitRepoUrl
+    externalGitBranch: externalGitBranch
+    enableApplicationInsights: enableApplicationInsights
+    logAnalyticsWorkspaceId: deployLogAnalytics ? logAnalytics!.outputs.resourceId : ''
+  }
+}
+
+// Chaos Studio Module
+module chaosStudio 'modules/chaos-studio.bicep' = {
+  scope: rg
+  name: '${uniqueString(deployment().name, location)}-chaos'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    tags: tags
+    appServiceResourceId: appService.outputs.webAppId
+    enableChaosStudio: enableChaosStudio
+    experimentDuration: chaosExperimentDuration
+  }
+}
+
+// Outputs
+@description('The name of the resource group.')
+output resourceGroupName string = rg.name
+
+@description('The resource ID of the resource group.')
+output resourceGroupId string = rg.id
+
+@description('The name of the Web App.')
+output webAppName string = appService.outputs.webAppName
+
+@description('The URL of the Web App.')
+output webAppUrl string = appService.outputs.webAppUrl
+
+@description('The resource ID of the Web App.')
+output webAppResourceId string = appService.outputs.webAppId
+
+@description('The name of the App Service Plan.')
+output appServicePlanName string = appService.outputs.appServicePlanName
+
+@description('The resource ID of the Chaos Studio experiment.')
+output chaosExperimentId string = enableChaosStudio ? chaosStudio.outputs.experimentId : ''
+
+@description('The name of the Chaos Studio experiment.')
+output chaosExperimentName string = enableChaosStudio ? chaosStudio.outputs.experimentName : ''
+
+@description('The resource ID of the Log Analytics workspace.')
+output logAnalyticsWorkspaceId string = deployLogAnalytics ? logAnalytics!.outputs.resourceId : ''
+
+@description('Instructions for SRE Agent setup.')
+output sreAgentInstructions string = '''
+=== SRE Agent Setup Instructions ===
+SRE Agent is currently in Preview and must be set up via the Azure Portal.
+
+1. Navigate to the Azure Portal: https://portal.azure.com
+2. Search for "Azure SRE Agent" in the search bar
+3. Select "+ Create" to create a new agent
+4. Configure the agent:
+   - Subscription: Your subscription
+   - Resource Group: Create a new one (e.g., rg-sre-agent)
+   - Name: my-sre-agent
+   - Region: East US 2 (or available region)
+5. Select "Select resource groups" and choose the resource group containing your App Service
+6. Click "Create"
+
+After creation, you can:
+- Chat with your agent to monitor the App Service
+- Use the "broken" deployment slot to simulate failures
+- Let the agent diagnose and remediate issues
+
+For more details, see: https://learn.microsoft.com/en-us/azure/sre-agent/troubleshoot-azure-app-service
+'''

--- a/infra/main.json
+++ b/infra/main.json
@@ -1,0 +1,9603 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.39.26.7824",
+      "templateHash": "9675241752027321982"
+    }
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 10,
+      "metadata": {
+        "description": "Required. Name prefix for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Azure region for deployment."
+      }
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "[format('rg-{0}-sre-agent', parameters('namePrefix'))]",
+      "metadata": {
+        "description": "Optional. Name of the resource group."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Optional. Tags to apply to all resources."
+      }
+    },
+    "appServiceSkuName": {
+      "type": "string",
+      "defaultValue": "S1",
+      "allowedValues": [
+        "F1",
+        "B1",
+        "B2",
+        "B3",
+        "S1",
+        "S2",
+        "S3",
+        "P1v3",
+        "P2v3",
+        "P3v3"
+      ],
+      "metadata": {
+        "description": "Optional. The SKU name for the App Service Plan."
+      }
+    },
+    "runtimeStack": {
+      "type": "string",
+      "defaultValue": "DOTNETCORE|9.0",
+      "allowedValues": [
+        "DOTNETCORE|9.0",
+        "DOTNETCORE|8.0",
+        "NODE|20-lts",
+        "NODE|18-lts",
+        "PYTHON|3.12",
+        "PYTHON|3.11"
+      ],
+      "metadata": {
+        "description": "Optional. The runtime stack for the web app."
+      }
+    },
+    "externalGitRepoUrl": {
+      "type": "string",
+      "defaultValue": "https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial",
+      "metadata": {
+        "description": "Optional. External Git repository URL for deployment."
+      }
+    },
+    "externalGitBranch": {
+      "type": "string",
+      "defaultValue": "main",
+      "metadata": {
+        "description": "Optional. Branch of the external Git repository."
+      }
+    },
+    "enableApplicationInsights": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable Application Insights."
+      }
+    },
+    "enableChaosStudio": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable Chaos Studio experiment."
+      }
+    },
+    "chaosExperimentDuration": {
+      "type": "string",
+      "defaultValue": "PT10M",
+      "metadata": {
+        "description": "Optional. Duration of the chaos experiment (ISO 8601 format)."
+      }
+    },
+    "deployLogAnalytics": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Deploy Log Analytics workspace for monitoring."
+      }
+    }
+  },
+  "variables": {
+    "logAnalyticsName": "[format('log-{0}', parameters('namePrefix'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2024-03-01",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('location')]",
+      "tags": "[union(parameters('tags'), createObject('sre-agent-demo', 'true', 'deployed-by', 'bicep'))]"
+    },
+    {
+      "condition": "[parameters('deployLogAnalytics')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-law', uniqueString(deployment().name, parameters('location')))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[variables('logAnalyticsName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "skuName": {
+            "value": "PerGB2018"
+          },
+          "dataRetention": {
+            "value": 30
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.32.4.45862",
+              "templateHash": "16982022366579989921"
+            },
+            "name": "Log Analytics Workspaces",
+            "description": "This module deploys a Log Analytics Workspace.",
+            "owner": "Azure/module-maintainers"
+          },
+          "definitions": {
+            "diagnosticSettingType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "useThisWorkspace": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. If set to `true`, the `workspaceResourceId` property is ignored."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              }
+            },
+            "gallerySolutionType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the solution.\nFor solutions authored by Microsoft, the name must be in the pattern: `SolutionType(WorkspaceName)`, for example: `AntiMalware(contoso-Logs)`.\nFor solutions authored by third parties, the name should be in the pattern: `SolutionType[WorkspaceName]`, for example `MySolution[contoso-Logs]`.\nThe solution type is case-sensitive."
+                  }
+                },
+                "plan": {
+                  "$ref": "#/definitions/solutionPlanType",
+                  "metadata": {
+                    "description": "Required. Plan for solution object supported by the OperationsManagement resource provider."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the gallery solutions to be created in the log analytics workspace."
+              }
+            },
+            "storageInsightsConfigType": {
+              "type": "object",
+              "properties": {
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Resource ID of the storage account to be linked."
+                  }
+                },
+                "containers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The names of the blob containers that the workspace should read."
+                  }
+                },
+                "tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. List of tables to be read by the workspace."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the storage insights configuration."
+              }
+            },
+            "linkedServiceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the linked service."
+                  }
+                },
+                "resourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource id of the resource that will be linked to the workspace. This should be used for linking resources which require read access."
+                  }
+                },
+                "writeAccessResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource id of the resource that will be linked to the workspace. This should be used for linking resources which require write access."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the linked service."
+              }
+            },
+            "linkedStorageAccountType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the link."
+                  }
+                },
+                "storageAccountIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minLength": 1,
+                  "metadata": {
+                    "description": "Required. Linked storage accounts resources Ids."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the linked storage account."
+              }
+            },
+            "savedSearchType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the saved search."
+                  }
+                },
+                "etag": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The ETag of the saved search. To override an existing saved search, use \"*\" or specify the current Etag."
+                  }
+                },
+                "category": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The category of the saved search. This helps the user to find a saved search faster."
+                  }
+                },
+                "displayName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Display name for the search."
+                  }
+                },
+                "functionAlias": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The function alias if query serves as a function."
+                  }
+                },
+                "functionParameters": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The optional function parameters if query serves as a function. Value should be in the following format: 'param-name1:type1 = default_value1, param-name2:type2 = default_value2'. For more examples and proper syntax please refer to /azure/kusto/query/functions/user-defined-functions."
+                  }
+                },
+                "query": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The query expression for the saved search."
+                  }
+                },
+                "tags": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The tags attached to the saved search."
+                  }
+                },
+                "version": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The version number of the query language. The current version is 2 and is the default."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the saved search."
+              }
+            },
+            "dataExportType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the data export."
+                  }
+                },
+                "destination": {
+                  "$ref": "#/definitions/destinationType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The destination of the data export."
+                  }
+                },
+                "enable": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable the data export."
+                  }
+                },
+                "tableNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The list of table names to export."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the data export."
+              }
+            },
+            "dataSourceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the data source."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The kind of data source."
+                  }
+                },
+                "linkedResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource id of the resource that will be linked to the workspace."
+                  }
+                },
+                "eventLogName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the event log to configure when kind is WindowsEvent."
+                  }
+                },
+                "eventTypes": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The event types to configure when kind is WindowsEvent."
+                  }
+                },
+                "objectName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the object to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                  }
+                },
+                "instanceName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the instance to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                  }
+                },
+                "intervalSeconds": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Interval in seconds to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                  }
+                },
+                "performanceCounters": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. List of counters to configure when the kind is LinuxPerformanceObject."
+                  }
+                },
+                "counterName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Counter name to configure when kind is WindowsPerformanceCounter."
+                  }
+                },
+                "state": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. State to configure when kind is IISLogs or LinuxSyslogCollection or LinuxPerformanceCollection."
+                  }
+                },
+                "syslogName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. System log to configure when kind is LinuxSyslog."
+                  }
+                },
+                "syslogSeverities": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Severities to configure when kind is LinuxSyslog."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags to configure in the resource."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the data source."
+              }
+            },
+            "tableType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the table."
+                  }
+                },
+                "plan": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The plan for the table."
+                  }
+                },
+                "restoredLogs": {
+                  "$ref": "#/definitions/restoredLogsType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The restored logs for the table."
+                  }
+                },
+                "schema": {
+                  "$ref": "#/definitions/schemaType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The schema for the table."
+                  }
+                },
+                "searchResults": {
+                  "$ref": "#/definitions/searchResultsType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The search results for the table."
+                  }
+                },
+                "retentionInDays": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The retention in days for the table."
+                  }
+                },
+                "totalRetentionInDays": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The total retention in days for the table."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The role assignments for the table."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties of the custom table."
+              }
+            },
+            "_1.columnType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The column name."
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "allowedValues": [
+                    "boolean",
+                    "dateTime",
+                    "dynamic",
+                    "guid",
+                    "int",
+                    "long",
+                    "real",
+                    "string"
+                  ],
+                  "metadata": {
+                    "description": "Required. The column type."
+                  }
+                },
+                "dataTypeHint": {
+                  "type": "string",
+                  "allowedValues": [
+                    "armPath",
+                    "guid",
+                    "ip",
+                    "uri"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The column data type logical hint."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The column description."
+                  }
+                },
+                "displayName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Column display name."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The parameters of the table column.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "table/main.bicep"
+                }
+              }
+            },
+            "destinationType": {
+              "type": "object",
+              "properties": {
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The destination resource ID."
+                  }
+                },
+                "metaData": {
+                  "type": "object",
+                  "properties": {
+                    "eventHubName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Allows to define an Event Hub name. Not applicable when destination is Storage Account."
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The destination metadata."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The data export destination properties.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "data-export/main.bicep"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+                }
+              }
+            },
+            "managedIdentityAllType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                },
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+                }
+              }
+            },
+            "restoredLogsType": {
+              "type": "object",
+              "properties": {
+                "sourceTable": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The table to restore data from."
+                  }
+                },
+                "startRestoreTime": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The timestamp to start the restore from (UTC)."
+                  }
+                },
+                "endRestoreTime": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The timestamp to end the restore by (UTC)."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The parameters of the restore operation that initiated the table.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "table/main.bicep"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+                }
+              }
+            },
+            "schemaType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The table name."
+                  }
+                },
+                "columns": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.columnType"
+                  },
+                  "metadata": {
+                    "description": "Required. A list of table custom columns."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The table description."
+                  }
+                },
+                "displayName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The table display name."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The table schema.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "table/main.bicep"
+                }
+              }
+            },
+            "searchResultsType": {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The search job query."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The search description."
+                  }
+                },
+                "limit": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Limit the search job to return up to specified number of rows."
+                  }
+                },
+                "startSearchTime": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The timestamp to start the search from (UTC)."
+                  }
+                },
+                "endSearchTime": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The timestamp to end the search by (UTC)."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The parameters of the search job that initiated the table.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "table/main.bicep"
+                }
+              }
+            },
+            "solutionPlanType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the solution to be created.\nFor solutions authored by Microsoft, the name must be in the pattern: `SolutionType(WorkspaceName)`, for example: `AntiMalware(contoso-Logs)`.\nFor solutions authored by third parties, it can be anything.\nThe solution type is case-sensitive.\nIf not provided, the value of the `name` parameter will be used."
+                  }
+                },
+                "product": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The product name of the deployed solution.\nFor Microsoft published gallery solution it should be `OMSGallery/{solutionType}`, for example `OMSGallery/AntiMalware`.\nFor a third party solution, it can be anything.\nThis is case sensitive."
+                  }
+                },
+                "publisher": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The publisher name of the deployed solution. For Microsoft published gallery solution, it is `Microsoft`, which is the default value."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/operations-management/solution:0.3.0"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Log Analytics workspace."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "skuName": {
+              "type": "string",
+              "defaultValue": "PerGB2018",
+              "allowedValues": [
+                "CapacityReservation",
+                "Free",
+                "LACluster",
+                "PerGB2018",
+                "PerNode",
+                "Premium",
+                "Standalone",
+                "Standard"
+              ],
+              "metadata": {
+                "description": "Optional. The name of the SKU."
+              }
+            },
+            "skuCapacityReservationLevel": {
+              "type": "int",
+              "defaultValue": 100,
+              "minValue": 100,
+              "maxValue": 5000,
+              "metadata": {
+                "description": "Optional. The capacity reservation level in GB for this workspace, when CapacityReservation sku is selected. Must be in increments of 100 between 100 and 5000."
+              }
+            },
+            "storageInsightsConfigs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/storageInsightsConfigType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. List of storage accounts to be read by the workspace."
+              }
+            },
+            "linkedServices": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/linkedServiceType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. List of services to be linked."
+              }
+            },
+            "linkedStorageAccounts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/linkedStorageAccountType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. List of Storage Accounts to be linked. Required if 'forceCmkForQuery' is set to 'true' and 'savedSearches' is not empty."
+              }
+            },
+            "savedSearches": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/savedSearchType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Kusto Query Language searches to save."
+              }
+            },
+            "dataExports": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dataExportType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. LAW data export instances to be deployed."
+              }
+            },
+            "dataSources": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dataSourceType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. LAW data sources to configure."
+              }
+            },
+            "tables": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/tableType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. LAW custom tables to be deployed."
+              }
+            },
+            "gallerySolutions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gallerySolutionType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. List of gallerySolutions to be created in the log analytics workspace."
+              }
+            },
+            "onboardWorkspaceToSentinel": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Onboard the Log Analytics Workspace to Sentinel. Requires 'SecurityInsights' solution to be in gallerySolutions."
+              }
+            },
+            "dataRetention": {
+              "type": "int",
+              "defaultValue": 365,
+              "minValue": 0,
+              "maxValue": 730,
+              "metadata": {
+                "description": "Optional. Number of days data will be retained for."
+              }
+            },
+            "dailyQuotaGb": {
+              "type": "int",
+              "defaultValue": -1,
+              "minValue": -1,
+              "metadata": {
+                "description": "Optional. The workspace daily quota for ingestion."
+              }
+            },
+            "publicNetworkAccessForIngestion": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Optional. The network access type for accessing Log Analytics ingestion."
+              }
+            },
+            "publicNetworkAccessForQuery": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Optional. The network access type for accessing Log Analytics query."
+              }
+            },
+            "managedIdentities": {
+              "$ref": "#/definitions/managedIdentityAllType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The managed identity definition for this resource. Only one type of identity is supported: system-assigned or user-assigned, but not both."
+              }
+            },
+            "useResourcePermissions": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Set to 'true' to use resource or workspace permissions and 'false' (or leave empty) to require workspace permissions."
+              }
+            },
+            "diagnosticSettings": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The diagnostic settings of the service."
+              }
+            },
+            "forceCmkForQuery": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Indicates whether customer managed storage is mandatory for query management."
+              }
+            },
+            "lock": {
+              "$ref": "#/definitions/lockType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The lock settings of the service."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the resource."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+              "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+              "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+              "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "Security Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb1c8493-542b-48eb-b624-b4c8fea62acd')]",
+              "Security Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '39bc4728-0917-49c7-9d2c-d95423bc2eb4')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+            }
+          },
+          "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[format('46d3xbcp.res.operationalinsights-workspace.{0}.{1}', replace('0.9.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "logAnalyticsWorkspace": {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2022-10-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "features": {
+                  "searchVersion": 1,
+                  "enableLogAccessUsingOnlyResourcePermissions": "[parameters('useResourcePermissions')]"
+                },
+                "sku": {
+                  "name": "[parameters('skuName')]",
+                  "capacityReservationLevel": "[if(equals(parameters('skuName'), 'CapacityReservation'), parameters('skuCapacityReservationLevel'), null())]"
+                },
+                "retentionInDays": "[parameters('dataRetention')]",
+                "workspaceCapping": {
+                  "dailyQuotaGb": "[parameters('dailyQuotaGb')]"
+                },
+                "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
+                "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]",
+                "forceCmkForQuery": "[parameters('forceCmkForQuery')]"
+              },
+              "identity": "[variables('identity')]"
+            },
+            "logAnalyticsWorkspace_diagnosticSettings": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_diagnosticSettings",
+                "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+              },
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "metrics",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                    "input": {
+                      "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                      "timeGrain": null
+                    }
+                  },
+                  {
+                    "name": "logs",
+                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs'))))]",
+                    "input": {
+                      "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'categoryGroup')]",
+                      "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'category')]",
+                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'enabled'), true())]"
+                    }
+                  }
+                ],
+                "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                "workspaceId": "[if(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'useThisWorkspace'), false()), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId'))]",
+                "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_sentinelOnboarding": {
+              "condition": "[and(not(empty(filter(coalesce(parameters('gallerySolutions'), createArray()), lambda('item', startsWith(lambdaVariables('item').name, 'SecurityInsights'))))), parameters('onboardWorkspaceToSentinel'))]",
+              "type": "Microsoft.SecurityInsights/onboardingStates",
+              "apiVersion": "2024-03-01",
+              "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
+              "name": "default",
+              "properties": {},
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_lock": {
+              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+              "type": "Microsoft.Authorization/locks",
+              "apiVersion": "2020-05-01",
+              "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+              "properties": {
+                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_roleAssignments": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_storageInsightConfigs": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_storageInsightConfigs",
+                "count": "[length(coalesce(parameters('storageInsightsConfigs'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-StorageInsightsConfig-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "containers": {
+                    "value": "[tryGet(coalesce(parameters('storageInsightsConfigs'), createArray())[copyIndex()], 'containers')]"
+                  },
+                  "tables": {
+                    "value": "[tryGet(coalesce(parameters('storageInsightsConfigs'), createArray())[copyIndex()], 'tables')]"
+                  },
+                  "storageAccountResourceId": {
+                    "value": "[coalesce(parameters('storageInsightsConfigs'), createArray())[copyIndex()].storageAccountResourceId]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "2068175338477699308"
+                    },
+                    "name": "Log Analytics Workspace Storage Insight Configs",
+                    "description": "This module deploys a Log Analytics Workspace Storage Insight Config.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "parameters": {
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[format('{0}-stinsconfig', last(split(parameters('storageAccountResourceId'), '/')))]",
+                      "metadata": {
+                        "description": "Optional. The name of the storage insights config."
+                      }
+                    },
+                    "storageAccountResourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The Azure Resource Manager ID of the storage account resource."
+                      }
+                    },
+                    "containers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The names of the blob containers that the workspace should read."
+                      }
+                    },
+                    "tables": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The names of the Azure tables that the workspace should read."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags to configure in the resource."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "storageAccount": {
+                      "existing": true,
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2022-09-01",
+                      "name": "[last(split(parameters('storageAccountResourceId'), '/'))]"
+                    },
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "storageinsightconfig": {
+                      "type": "Microsoft.OperationalInsights/workspaces/storageInsightConfigs",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "containers": "[parameters('containers')]",
+                        "tables": "[parameters('tables')]",
+                        "storageAccount": {
+                          "id": "[parameters('storageAccountResourceId')]",
+                          "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', last(split(parameters('storageAccountResourceId'), '/'))), '2022-09-01').keys[0].value]"
+                        }
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed storage insights configuration."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/storageInsightConfigs', parameters('logAnalyticsWorkspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the storage insight configuration is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the storage insights configuration."
+                      },
+                      "value": "[parameters('name')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_linkedServices": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_linkedServices",
+                "count": "[length(coalesce(parameters('linkedServices'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-LinkedService-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('linkedServices'), createArray())[copyIndex()].name]"
+                  },
+                  "resourceId": {
+                    "value": "[tryGet(coalesce(parameters('linkedServices'), createArray())[copyIndex()], 'resourceId')]"
+                  },
+                  "writeAccessResourceId": {
+                    "value": "[tryGet(coalesce(parameters('linkedServices'), createArray())[copyIndex()], 'writeAccessResourceId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "7966743093368602805"
+                    },
+                    "name": "Log Analytics Workspace Linked Services",
+                    "description": "This module deploys a Log Analytics Workspace Linked Service.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "parameters": {
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the link."
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require read access."
+                      }
+                    },
+                    "writeAccessResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require write access."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags to configure in the resource."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "linkedService": {
+                      "type": "Microsoft.OperationalInsights/workspaces/linkedServices",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "resourceId": "[parameters('resourceId')]",
+                        "writeAccessResourceId": "[parameters('writeAccessResourceId')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed linked service."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed linked service."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/linkedServices', parameters('logAnalyticsWorkspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the linked service is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_linkedStorageAccounts": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_linkedStorageAccounts",
+                "count": "[length(coalesce(parameters('linkedStorageAccounts'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-LinkedStorageAccount-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('linkedStorageAccounts'), createArray())[copyIndex()].name]"
+                  },
+                  "storageAccountIds": {
+                    "value": "[coalesce(parameters('linkedStorageAccounts'), createArray())[copyIndex()].storageAccountIds]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "5881171536836718740"
+                    },
+                    "name": "Log Analytics Workspace Linked Storage Accounts",
+                    "description": "This module deploys a Log Analytics Workspace Linked Storage Account.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "parameters": {
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Query",
+                        "Alerts",
+                        "CustomLogs",
+                        "AzureWatson"
+                      ],
+                      "metadata": {
+                        "description": "Required. Name of the link."
+                      }
+                    },
+                    "storageAccountIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minLength": 1,
+                      "metadata": {
+                        "description": "Required. Linked storage accounts resources Ids."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "linkedStorageAccount": {
+                      "type": "Microsoft.OperationalInsights/workspaces/linkedStorageAccounts",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
+                      "properties": {
+                        "storageAccountIds": "[parameters('storageAccountIds')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed linked storage account."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed linked storage account."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/linkedStorageAccounts', parameters('logAnalyticsWorkspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the linked storage account is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_savedSearches": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_savedSearches",
+                "count": "[length(coalesce(parameters('savedSearches'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-SavedSearch-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[format('{0}{1}', coalesce(parameters('savedSearches'), createArray())[copyIndex()].name, uniqueString(deployment().name))]"
+                  },
+                  "etag": {
+                    "value": "[tryGet(coalesce(parameters('savedSearches'), createArray())[copyIndex()], 'etag')]"
+                  },
+                  "displayName": {
+                    "value": "[coalesce(parameters('savedSearches'), createArray())[copyIndex()].displayName]"
+                  },
+                  "category": {
+                    "value": "[coalesce(parameters('savedSearches'), createArray())[copyIndex()].category]"
+                  },
+                  "query": {
+                    "value": "[coalesce(parameters('savedSearches'), createArray())[copyIndex()].query]"
+                  },
+                  "functionAlias": {
+                    "value": "[tryGet(coalesce(parameters('savedSearches'), createArray())[copyIndex()], 'functionAlias')]"
+                  },
+                  "functionParameters": {
+                    "value": "[tryGet(coalesce(parameters('savedSearches'), createArray())[copyIndex()], 'functionParameters')]"
+                  },
+                  "tags": {
+                    "value": "[tryGet(coalesce(parameters('savedSearches'), createArray())[copyIndex()], 'tags')]"
+                  },
+                  "version": {
+                    "value": "[tryGet(coalesce(parameters('savedSearches'), createArray())[copyIndex()], 'version')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "11293384964293270173"
+                    },
+                    "name": "Log Analytics Workspace Saved Searches",
+                    "description": "This module deploys a Log Analytics Workspace Saved Search.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "parameters": {
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the saved search."
+                      }
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Display name for the search."
+                      }
+                    },
+                    "category": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Query category."
+                      }
+                    },
+                    "query": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Kusto Query to be stored."
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags to configure in the resource."
+                      }
+                    },
+                    "functionAlias": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The function alias if query serves as a function."
+                      }
+                    },
+                    "functionParameters": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The optional function parameters if query serves as a function. Value should be in the following format: \"param-name1:type1 = default_value1, param-name2:type2 = default_value2\". For more examples and proper syntax please refer to /azure/kusto/query/functions/user-defined-functions."
+                      }
+                    },
+                    "version": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The version number of the query language."
+                      }
+                    },
+                    "etag": {
+                      "type": "string",
+                      "defaultValue": "*",
+                      "metadata": {
+                        "description": "Optional. The ETag of the saved search. To override an existing saved search, use \"*\" or specify the current Etag."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "savedSearch": {
+                      "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
+                      "properties": {
+                        "etag": "[parameters('etag')]",
+                        "tags": "[coalesce(parameters('tags'), createArray())]",
+                        "displayName": "[parameters('displayName')]",
+                        "category": "[parameters('category')]",
+                        "query": "[parameters('query')]",
+                        "functionAlias": "[parameters('functionAlias')]",
+                        "functionParameters": "[parameters('functionParameters')]",
+                        "version": "[parameters('version')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed saved search."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('logAnalyticsWorkspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the saved search is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed saved search."
+                      },
+                      "value": "[parameters('name')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace",
+                "logAnalyticsWorkspace_linkedStorageAccounts"
+              ]
+            },
+            "logAnalyticsWorkspace_dataExports": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_dataExports",
+                "count": "[length(coalesce(parameters('dataExports'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-DataExport-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "workspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('dataExports'), createArray())[copyIndex()].name]"
+                  },
+                  "destination": {
+                    "value": "[tryGet(coalesce(parameters('dataExports'), createArray())[copyIndex()], 'destination')]"
+                  },
+                  "enable": {
+                    "value": "[tryGet(coalesce(parameters('dataExports'), createArray())[copyIndex()], 'enable')]"
+                  },
+                  "tableNames": {
+                    "value": "[tryGet(coalesce(parameters('dataExports'), createArray())[copyIndex()], 'tableNames')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "4044138176233388426"
+                    },
+                    "name": "Log Analytics Workspace Data Exports",
+                    "description": "This module deploys a Log Analytics Workspace Data Export.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "definitions": {
+                    "destinationType": {
+                      "type": "object",
+                      "properties": {
+                        "resourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The destination resource ID."
+                          }
+                        },
+                        "metaData": {
+                          "type": "object",
+                          "properties": {
+                            "eventHubName": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Allows to define an Event Hub name. Not applicable when destination is Storage Account."
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The destination metadata."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The data export destination properties."
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 4,
+                      "maxLength": 63,
+                      "metadata": {
+                        "description": "Required. The data export rule name."
+                      }
+                    },
+                    "workspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent workspaces. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "destination": {
+                      "$ref": "#/definitions/destinationType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Destination properties."
+                      }
+                    },
+                    "enable": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Active when enabled."
+                      }
+                    },
+                    "tableNames": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minLength": 1,
+                      "metadata": {
+                        "description": "Required. An array of tables to export, for example: ['Heartbeat', 'SecurityEvent']."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('workspaceName')]"
+                    },
+                    "dataExport": {
+                      "type": "Microsoft.OperationalInsights/workspaces/dataExports",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('workspaceName'), parameters('name'))]",
+                      "properties": {
+                        "destination": "[parameters('destination')]",
+                        "enable": "[parameters('enable')]",
+                        "tableNames": "[parameters('tableNames')]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the data export."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the data export."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/dataExports', parameters('workspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the data export was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_dataSources": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_dataSources",
+                "count": "[length(coalesce(parameters('dataSources'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-DataSource-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('dataSources'), createArray())[copyIndex()].name]"
+                  },
+                  "kind": {
+                    "value": "[coalesce(parameters('dataSources'), createArray())[copyIndex()].kind]"
+                  },
+                  "linkedResourceId": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'linkedResourceId')]"
+                  },
+                  "eventLogName": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'eventLogName')]"
+                  },
+                  "eventTypes": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'eventTypes')]"
+                  },
+                  "objectName": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'objectName')]"
+                  },
+                  "instanceName": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'instanceName')]"
+                  },
+                  "intervalSeconds": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'intervalSeconds')]"
+                  },
+                  "counterName": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'counterName')]"
+                  },
+                  "state": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'state')]"
+                  },
+                  "syslogName": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'syslogName')]"
+                  },
+                  "syslogSeverities": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'syslogSeverities')]"
+                  },
+                  "performanceCounters": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'performanceCounters')]"
+                  },
+                  "tags": {
+                    "value": "[tryGet(coalesce(parameters('dataSources'), createArray())[copyIndex()], 'tags')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "17349115996815882874"
+                    },
+                    "name": "Log Analytics Workspace Datasources",
+                    "description": "This module deploys a Log Analytics Workspace Data Source.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "parameters": {
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the data source."
+                      }
+                    },
+                    "kind": {
+                      "type": "string",
+                      "defaultValue": "AzureActivityLog",
+                      "allowedValues": [
+                        "AzureActivityLog",
+                        "WindowsEvent",
+                        "WindowsPerformanceCounter",
+                        "IISLogs",
+                        "LinuxSyslog",
+                        "LinuxSyslogCollection",
+                        "LinuxPerformanceObject",
+                        "LinuxPerformanceCollection"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The kind of the data source."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags to configure in the resource."
+                      }
+                    },
+                    "linkedResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Resource ID of the resource to be linked."
+                      }
+                    },
+                    "eventLogName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Windows event log name to configure when kind is WindowsEvent."
+                      }
+                    },
+                    "eventTypes": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Optional. Windows event types to configure when kind is WindowsEvent."
+                      }
+                    },
+                    "objectName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Name of the object to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                      }
+                    },
+                    "instanceName": {
+                      "type": "string",
+                      "defaultValue": "*",
+                      "metadata": {
+                        "description": "Optional. Name of the instance to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                      }
+                    },
+                    "intervalSeconds": {
+                      "type": "int",
+                      "defaultValue": 60,
+                      "metadata": {
+                        "description": "Optional. Interval in seconds to configure when kind is WindowsPerformanceCounter or LinuxPerformanceObject."
+                      }
+                    },
+                    "performanceCounters": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Optional. List of counters to configure when the kind is LinuxPerformanceObject."
+                      }
+                    },
+                    "counterName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Counter name to configure when kind is WindowsPerformanceCounter."
+                      }
+                    },
+                    "state": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. State to configure when kind is IISLogs or LinuxSyslogCollection or LinuxPerformanceCollection."
+                      }
+                    },
+                    "syslogName": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. System log to configure when kind is LinuxSyslog."
+                      }
+                    },
+                    "syslogSeverities": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Optional. Severities to configure when kind is LinuxSyslog."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "dataSource": {
+                      "type": "Microsoft.OperationalInsights/workspaces/dataSources",
+                      "apiVersion": "2020-08-01",
+                      "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
+                      "kind": "[parameters('kind')]",
+                      "tags": "[parameters('tags')]",
+                      "properties": {
+                        "linkedResourceId": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'AzureActivityLog')), parameters('linkedResourceId'), null())]",
+                        "eventLogName": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'WindowsEvent')), parameters('eventLogName'), null())]",
+                        "eventTypes": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'WindowsEvent')), parameters('eventTypes'), null())]",
+                        "objectName": "[if(and(not(empty(parameters('kind'))), or(equals(parameters('kind'), 'WindowsPerformanceCounter'), equals(parameters('kind'), 'LinuxPerformanceObject'))), parameters('objectName'), null())]",
+                        "instanceName": "[if(and(not(empty(parameters('kind'))), or(equals(parameters('kind'), 'WindowsPerformanceCounter'), equals(parameters('kind'), 'LinuxPerformanceObject'))), parameters('instanceName'), null())]",
+                        "intervalSeconds": "[if(and(not(empty(parameters('kind'))), or(equals(parameters('kind'), 'WindowsPerformanceCounter'), equals(parameters('kind'), 'LinuxPerformanceObject'))), parameters('intervalSeconds'), null())]",
+                        "counterName": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'WindowsPerformanceCounter')), parameters('counterName'), null())]",
+                        "state": "[if(and(not(empty(parameters('kind'))), or(or(equals(parameters('kind'), 'IISLogs'), equals(parameters('kind'), 'LinuxSyslogCollection')), equals(parameters('kind'), 'LinuxPerformanceCollection'))), parameters('state'), null())]",
+                        "syslogName": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'LinuxSyslog')), parameters('syslogName'), null())]",
+                        "syslogSeverities": "[if(and(not(empty(parameters('kind'))), or(equals(parameters('kind'), 'LinuxSyslog'), equals(parameters('kind'), 'LinuxPerformanceObject'))), parameters('syslogSeverities'), null())]",
+                        "performanceCounters": "[if(and(not(empty(parameters('kind'))), equals(parameters('kind'), 'LinuxPerformanceObject')), parameters('performanceCounters'), null())]"
+                      }
+                    }
+                  },
+                  "outputs": {
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed data source."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/dataSources', parameters('logAnalyticsWorkspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the data source is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed data source."
+                      },
+                      "value": "[parameters('name')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_tables": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_tables",
+                "count": "[length(coalesce(parameters('tables'), createArray()))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-Table-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "workspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "name": {
+                    "value": "[coalesce(parameters('tables'), createArray())[copyIndex()].name]"
+                  },
+                  "plan": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'plan')]"
+                  },
+                  "schema": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'schema')]"
+                  },
+                  "retentionInDays": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'retentionInDays')]"
+                  },
+                  "totalRetentionInDays": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'totalRetentionInDays')]"
+                  },
+                  "restoredLogs": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'restoredLogs')]"
+                  },
+                  "searchResults": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'searchResults')]"
+                  },
+                  "roleAssignments": {
+                    "value": "[tryGet(coalesce(parameters('tables'), createArray())[copyIndex()], 'roleAssignments')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "16645325284402756922"
+                    },
+                    "name": "Log Analytics Workspace Tables",
+                    "description": "This module deploys a Log Analytics Workspace Table.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "definitions": {
+                    "restoredLogsType": {
+                      "type": "object",
+                      "properties": {
+                        "sourceTable": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The table to restore data from."
+                          }
+                        },
+                        "startRestoreTime": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The timestamp to start the restore from (UTC)."
+                          }
+                        },
+                        "endRestoreTime": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The timestamp to end the restore by (UTC)."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The parameters of the restore operation that initiated the table."
+                      }
+                    },
+                    "schemaType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The table name."
+                          }
+                        },
+                        "columns": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/columnType"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of table custom columns."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The table description."
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The table display name."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The table schema."
+                      }
+                    },
+                    "columnType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The column name."
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "allowedValues": [
+                            "boolean",
+                            "dateTime",
+                            "dynamic",
+                            "guid",
+                            "int",
+                            "long",
+                            "real",
+                            "string"
+                          ],
+                          "metadata": {
+                            "description": "Required. The column type."
+                          }
+                        },
+                        "dataTypeHint": {
+                          "type": "string",
+                          "allowedValues": [
+                            "armPath",
+                            "guid",
+                            "ip",
+                            "uri"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The column data type logical hint."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The column description."
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Column display name."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The parameters of the table column."
+                      }
+                    },
+                    "searchResultsType": {
+                      "type": "object",
+                      "properties": {
+                        "query": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The search job query."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The search description."
+                          }
+                        },
+                        "limit": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Limit the search job to return up to specified number of rows."
+                          }
+                        },
+                        "startSearchTime": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The timestamp to start the search from (UTC)."
+                          }
+                        },
+                        "endSearchTime": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The timestamp to end the search by (UTC)."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The parameters of the search job that initiated the table."
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the table."
+                      }
+                    },
+                    "workspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Conditional. The name of the parent workspaces. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "plan": {
+                      "type": "string",
+                      "defaultValue": "Analytics",
+                      "allowedValues": [
+                        "Basic",
+                        "Analytics"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Instruct the system how to handle and charge the logs ingested to this table."
+                      }
+                    },
+                    "restoredLogs": {
+                      "$ref": "#/definitions/restoredLogsType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Restore parameters."
+                      }
+                    },
+                    "retentionInDays": {
+                      "type": "int",
+                      "defaultValue": -1,
+                      "minValue": -1,
+                      "maxValue": 730,
+                      "metadata": {
+                        "description": "Optional. The table retention in days, between 4 and 730. Setting this property to -1 will default to the workspace retention."
+                      }
+                    },
+                    "schema": {
+                      "$ref": "#/definitions/schemaType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Table's schema."
+                      }
+                    },
+                    "searchResults": {
+                      "$ref": "#/definitions/searchResultsType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Parameters of the search job that initiated this table."
+                      }
+                    },
+                    "totalRetentionInDays": {
+                      "type": "int",
+                      "defaultValue": -1,
+                      "minValue": -1,
+                      "maxValue": 2555,
+                      "metadata": {
+                        "description": "Optional. The table total retention in days, between 4 and 2555. Setting this property to -1 will default to table retention."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": {
+                    "workspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2022-10-01",
+                      "name": "[parameters('workspaceName')]"
+                    },
+                    "table": {
+                      "type": "Microsoft.OperationalInsights/workspaces/tables",
+                      "apiVersion": "2022-10-01",
+                      "name": "[format('{0}/{1}', parameters('workspaceName'), parameters('name'))]",
+                      "properties": {
+                        "plan": "[parameters('plan')]",
+                        "restoredLogs": "[parameters('restoredLogs')]",
+                        "retentionInDays": "[parameters('retentionInDays')]",
+                        "schema": "[parameters('schema')]",
+                        "searchResults": "[parameters('searchResults')]",
+                        "totalRetentionInDays": "[parameters('totalRetentionInDays')]"
+                      }
+                    },
+                    "table_roleAssignments": {
+                      "copy": {
+                        "name": "table_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}/tables/{1}', parameters('workspaceName'), parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.OperationalInsights/workspaces/tables', parameters('workspaceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "table"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the table."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the table."
+                      },
+                      "value": "[resourceId('Microsoft.OperationalInsights/workspaces/tables', parameters('workspaceName'), parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the table was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            },
+            "logAnalyticsWorkspace_solutions": {
+              "copy": {
+                "name": "logAnalyticsWorkspace_solutions",
+                "count": "[length(coalesce(parameters('gallerySolutions'), createArray()))]"
+              },
+              "condition": "[not(empty(parameters('gallerySolutions')))]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-LAW-Solution-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[coalesce(parameters('gallerySolutions'), createArray())[copyIndex()].name]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "logAnalyticsWorkspaceName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "plan": {
+                    "value": "[coalesce(parameters('gallerySolutions'), createArray())[copyIndex()].plan]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('gallerySolutions'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.30.23.60470",
+                      "templateHash": "1867653058254938383"
+                    },
+                    "name": "Operations Management Solutions",
+                    "description": "This module deploys an Operations Management Solution.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "definitions": {
+                    "solutionPlanType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Name of the solution to be created.\nFor solutions authored by Microsoft, the name must be in the pattern: `SolutionType(WorkspaceName)`, for example: `AntiMalware(contoso-Logs)`.\nFor solutions authored by third parties, it can be anything.\nThe solution type is case-sensitive.\nIf not provided, the value of the `name` parameter will be used."
+                          }
+                        },
+                        "product": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The product name of the deployed solution.\nFor Microsoft published gallery solution it should be `OMSGallery/{solutionType}`, for example `OMSGallery/AntiMalware`.\nFor a third party solution, it can be anything.\nThis is case sensitive."
+                          }
+                        },
+                        "publisher": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The publisher name of the deployed solution. For Microsoft published gallery solution, it is `Microsoft`, which is the default value."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the solution.\nFor solutions authored by Microsoft, the name must be in the pattern: `SolutionType(WorkspaceName)`, for example: `AntiMalware(contoso-Logs)`.\nFor solutions authored by third parties, the name should be in the pattern: `SolutionType[WorkspaceName]`, for example `MySolution[contoso-Logs]`.\nThe solution type is case-sensitive."
+                      }
+                    },
+                    "plan": {
+                      "$ref": "#/definitions/solutionPlanType",
+                      "metadata": {
+                        "description": "Required. Plan for solution object supported by the OperationsManagement resource provider."
+                      }
+                    },
+                    "logAnalyticsWorkspaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the Log Analytics workspace where the solution will be deployed/enabled."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('46d3xbcp.res.operationsmanagement-solution.{0}.{1}', replace('0.3.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "logAnalyticsWorkspace": {
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2021-06-01",
+                      "name": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "solution": {
+                      "type": "Microsoft.OperationsManagement/solutions",
+                      "apiVersion": "2015-11-01-preview",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+                      },
+                      "plan": {
+                        "name": "[coalesce(tryGet(parameters('plan'), 'name'), parameters('name'))]",
+                        "promotionCode": "",
+                        "product": "[parameters('plan').product]",
+                        "publisher": "[coalesce(tryGet(parameters('plan'), 'publisher'), 'Microsoft')]"
+                      },
+                      "dependsOn": [
+                        "logAnalyticsWorkspace"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the deployed solution."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the deployed solution."
+                      },
+                      "value": "[resourceId('Microsoft.OperationsManagement/solutions', parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group where the solution is deployed."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('solution', '2015-11-01-preview', 'full').location]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "logAnalyticsWorkspace"
+              ]
+            }
+          },
+          "outputs": {
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed log analytics workspace."
+              },
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed log analytics workspace."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed log analytics workspace."
+              },
+              "value": "[parameters('name')]"
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The ID associated with the workspace."
+              },
+              "value": "[reference('logAnalyticsWorkspace').customerId]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('logAnalyticsWorkspace', '2022-10-01', 'full').location]"
+            },
+            "systemAssignedMIPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "The principal ID of the system assigned identity."
+              },
+              "value": "[coalesce(tryGet(tryGet(reference('logAnalyticsWorkspace', '2022-10-01', 'full'), 'identity'), 'principalId'), '')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-appservice', uniqueString(deployment().name, parameters('location')))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "namePrefix": {
+            "value": "[parameters('namePrefix')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "skuName": {
+            "value": "[parameters('appServiceSkuName')]"
+          },
+          "runtimeStack": {
+            "value": "[parameters('runtimeStack')]"
+          },
+          "externalGitRepoUrl": {
+            "value": "[parameters('externalGitRepoUrl')]"
+          },
+          "externalGitBranch": {
+            "value": "[parameters('externalGitBranch')]"
+          },
+          "enableApplicationInsights": {
+            "value": "[parameters('enableApplicationInsights')]"
+          },
+          "logAnalyticsWorkspaceId": "[if(parameters('deployLogAnalytics'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-law', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.resourceId.value), createObject('value', ''))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "12418563692569622"
+            }
+          },
+          "parameters": {
+            "namePrefix": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name prefix for resources."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags for all resources."
+              }
+            },
+            "skuName": {
+              "type": "string",
+              "defaultValue": "S1",
+              "allowedValues": [
+                "F1",
+                "B1",
+                "B2",
+                "B3",
+                "S1",
+                "S2",
+                "S3",
+                "P1v3",
+                "P2v3",
+                "P3v3"
+              ],
+              "metadata": {
+                "description": "Optional. The SKU name for the App Service Plan."
+              }
+            },
+            "runtimeStack": {
+              "type": "string",
+              "defaultValue": "DOTNETCORE|9.0",
+              "allowedValues": [
+                "DOTNETCORE|9.0",
+                "DOTNETCORE|8.0",
+                "NODE|20-lts",
+                "NODE|18-lts",
+                "PYTHON|3.12",
+                "PYTHON|3.11"
+              ],
+              "metadata": {
+                "description": "Optional. The runtime stack for the web app."
+              }
+            },
+            "externalGitRepoUrl": {
+              "type": "string",
+              "defaultValue": "https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial",
+              "metadata": {
+                "description": "Optional. External Git repository URL for deployment."
+              }
+            },
+            "externalGitBranch": {
+              "type": "string",
+              "defaultValue": "main",
+              "metadata": {
+                "description": "Optional. Branch of the external Git repository."
+              }
+            },
+            "enableApplicationInsights": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable Application Insights."
+              }
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Log Analytics Workspace resource ID for diagnostics."
+              }
+            }
+          },
+          "variables": {
+            "appServicePlanName": "[format('asp-{0}', parameters('namePrefix'))]",
+            "webAppName": "[format('app-{0}', parameters('namePrefix'))]",
+            "appInsightsName": "[format('appi-{0}', parameters('namePrefix'))]",
+            "isLinux": "[or(contains(parameters('runtimeStack'), 'NODE'), contains(parameters('runtimeStack'), 'PYTHON'))]"
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableApplicationInsights')]",
+              "type": "Microsoft.Insights/components",
+              "apiVersion": "2020-02-02",
+              "name": "[variables('appInsightsName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "kind": "web",
+              "properties": {
+                "Application_Type": "web",
+                "WorkspaceResourceId": "[if(not(empty(parameters('logAnalyticsWorkspaceId'))), parameters('logAnalyticsWorkspaceId'), null())]"
+              }
+            },
+            {
+              "type": "Microsoft.Web/sites/sourcecontrols",
+              "apiVersion": "2023-12-01",
+              "name": "[format('{0}/web', variables('webAppName'))]",
+              "properties": {
+                "repoUrl": "[parameters('externalGitRepoUrl')]",
+                "branch": "[parameters('externalGitBranch')]",
+                "isManualIntegration": true
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location'))))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/slots/sourcecontrols",
+              "apiVersion": "2023-12-01",
+              "name": "[format('{0}/broken/web', variables('webAppName'))]",
+              "properties": {
+                "repoUrl": "[parameters('externalGitRepoUrl')]",
+                "branch": "[parameters('externalGitBranch')]",
+                "isManualIntegration": true
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location'))))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/slots/config",
+              "apiVersion": "2023-12-01",
+              "name": "[format('{0}/broken/appsettings', variables('webAppName'))]",
+              "properties": {
+                "INJECT_ERROR": "1",
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "[if(parameters('enableApplicationInsights'), reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ConnectionString, '')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]",
+                "[resourceId('Microsoft.Web/sites/slots/sourcecontrols', split(format('{0}/broken/web', variables('webAppName')), '/')[0], split(format('{0}/broken/web', variables('webAppName')), '/')[1], split(format('{0}/broken/web', variables('webAppName')), '/')[2])]"
+              ]
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-asp', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[variables('appServicePlanName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "skuName": {
+                    "value": "[parameters('skuName')]"
+                  },
+                  "skuCapacity": {
+                    "value": 1
+                  },
+                  "kind": "[if(variables('isLinux'), createObject('value', 'linux'), createObject('value', 'app'))]",
+                  "reserved": {
+                    "value": "[variables('isLinux')]"
+                  },
+                  "diagnosticSettings": "[if(not(empty(parameters('logAnalyticsWorkspaceId'))), createObject('value', createArray(createObject('workspaceResourceId', parameters('logAnalyticsWorkspaceId'), 'metricCategories', createArray(createObject('category', 'AllMetrics'))))), createObject('value', createArray()))]"
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.32.4.45862",
+                      "templateHash": "13070013363315850466"
+                    },
+                    "name": "App Service Plan",
+                    "description": "This module deploys an App Service Plan.",
+                    "owner": "Azure/module-maintainers"
+                  },
+                  "definitions": {
+                    "diagnosticSettingMetricsOnlyType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of diagnostic setting."
+                          }
+                        },
+                        "metricCategories": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                          }
+                        },
+                        "logAnalyticsDestinationType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "AzureDiagnostics",
+                            "Dedicated"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                          }
+                        },
+                        "workspaceResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "storageAccountResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "eventHubAuthorizationRuleResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                          }
+                        },
+                        "eventHubName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "marketplacePartnerResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a diagnostic setting. To be used if only metrics are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60,
+                      "metadata": {
+                        "description": "Required. Name of the app service plan."
+                      }
+                    },
+                    "skuName": {
+                      "type": "string",
+                      "defaultValue": "P1v3",
+                      "metadata": {
+                        "example": "  'F1'\n  'B1'\n  'P1v3'\n  'I1v2'\n  'FC1'\n  ",
+                        "description": "Optional. The name of the SKU will Determine the tier, size, family of the App Service Plan. This defaults to P1v3 to leverage availability zones."
+                      }
+                    },
+                    "skuCapacity": {
+                      "type": "int",
+                      "defaultValue": 3,
+                      "metadata": {
+                        "description": "Optional. Number of workers associated with the App Service Plan. This defaults to 3, to leverage availability zones."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "kind": {
+                      "type": "string",
+                      "defaultValue": "app",
+                      "allowedValues": [
+                        "app",
+                        "elastic",
+                        "functionApp",
+                        "windows",
+                        "linux"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Kind of server OS."
+                      }
+                    },
+                    "reserved": {
+                      "type": "bool",
+                      "defaultValue": "[equals(parameters('kind'), 'linux')]",
+                      "metadata": {
+                        "description": "Conditional. Defaults to false when creating Windows/app App Service Plan. Required if creating a Linux App Service Plan and must be set to true."
+                      }
+                    },
+                    "appServiceEnvironmentId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The Resource ID of the App Service Environment to use for the App Service Plan."
+                      }
+                    },
+                    "workerTierName": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Target worker tier assigned to the App Service plan."
+                      }
+                    },
+                    "perSiteScaling": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. If true, apps assigned to this App Service plan can be scaled independently. If false, apps assigned to this App Service plan will scale to all instances of the plan."
+                      }
+                    },
+                    "elasticScaleEnabled": {
+                      "type": "bool",
+                      "defaultValue": "[greater(parameters('maximumElasticWorkerCount'), 1)]",
+                      "metadata": {
+                        "description": "Optional. Enable/Disable ElasticScaleEnabled App Service Plan."
+                      }
+                    },
+                    "maximumElasticWorkerCount": {
+                      "type": "int",
+                      "defaultValue": 1,
+                      "metadata": {
+                        "description": "Optional. Maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan."
+                      }
+                    },
+                    "targetWorkerCount": {
+                      "type": "int",
+                      "defaultValue": 0,
+                      "metadata": {
+                        "description": "Optional. Scaling worker count."
+                      }
+                    },
+                    "targetWorkerSize": {
+                      "type": "int",
+                      "defaultValue": 0,
+                      "allowedValues": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "metadata": {
+                        "description": "Optional. The instance size of the hosting plan (small, medium, or large)."
+                      }
+                    },
+                    "zoneRedundant": {
+                      "type": "bool",
+                      "defaultValue": "[if(or(startsWith(parameters('skuName'), 'P'), startsWith(parameters('skuName'), 'EP')), true(), false())]",
+                      "metadata": {
+                        "description": "Optional. Zone Redundant server farms can only be used on Premium or ElasticPremium SKU tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs)."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    },
+                    "diagnosticSettings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/diagnosticSettingMetricsOnlyType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The diagnostic settings of the service."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                      "Web Plan Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')]",
+                      "Website Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('46d3xbcp.res.web-serverfarm.{0}.{1}', replace('0.4.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "appServicePlan": {
+                      "type": "Microsoft.Web/serverfarms",
+                      "apiVersion": "2022-09-01",
+                      "name": "[parameters('name')]",
+                      "kind": "[parameters('kind')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "sku": {
+                        "name": "[parameters('skuName')]",
+                        "capacity": "[if(equals(parameters('skuName'), 'FC1'), null(), parameters('skuCapacity'))]",
+                        "tier": "[if(equals(parameters('skuName'), 'FC1'), 'FlexConsumption', null())]"
+                      },
+                      "properties": {
+                        "workerTierName": "[parameters('workerTierName')]",
+                        "hostingEnvironmentProfile": "[if(not(empty(parameters('appServiceEnvironmentId'))), createObject('id', parameters('appServiceEnvironmentId')), null())]",
+                        "perSiteScaling": "[parameters('perSiteScaling')]",
+                        "maximumElasticWorkerCount": "[parameters('maximumElasticWorkerCount')]",
+                        "elasticScaleEnabled": "[parameters('elasticScaleEnabled')]",
+                        "reserved": "[parameters('reserved')]",
+                        "targetWorkerCount": "[parameters('targetWorkerCount')]",
+                        "targetWorkerSizeId": "[parameters('targetWorkerSize')]",
+                        "zoneRedundant": "[parameters('zoneRedundant')]"
+                      }
+                    },
+                    "appServicePlan_diagnosticSettings": {
+                      "copy": {
+                        "name": "appServicePlan_diagnosticSettings",
+                        "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                      },
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2021-05-01-preview",
+                      "scope": "[format('Microsoft.Web/serverfarms/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "metrics",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                            "input": {
+                              "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                              "timeGrain": null
+                            }
+                          }
+                        ],
+                        "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                        "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                        "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                        "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                        "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                        "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                      },
+                      "dependsOn": [
+                        "appServicePlan"
+                      ]
+                    },
+                    "appServicePlan_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.Web/serverfarms/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                      },
+                      "dependsOn": [
+                        "appServicePlan"
+                      ]
+                    },
+                    "appServicePlan_roleAssignments": {
+                      "copy": {
+                        "name": "appServicePlan_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.Web/serverfarms/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Web/serverfarms', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "appServicePlan"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group the app service plan was deployed into."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the app service plan."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the app service plan."
+                      },
+                      "value": "[resourceId('Microsoft.Web/serverfarms', parameters('name'))]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('appServicePlan', '2022-09-01', 'full').location]"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-webapp', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[variables('webAppName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "kind": "[if(variables('isLinux'), createObject('value', 'app,linux'), createObject('value', 'app'))]",
+                  "serverFarmResourceId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-asp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.resourceId.value]"
+                  },
+                  "httpsOnly": {
+                    "value": true
+                  },
+                  "publicNetworkAccess": {
+                    "value": "Enabled"
+                  },
+                  "siteConfig": {
+                    "value": {
+                      "linuxFxVersion": "[if(variables('isLinux'), parameters('runtimeStack'), null())]",
+                      "netFrameworkVersion": "[if(and(not(variables('isLinux')), contains(parameters('runtimeStack'), 'DOTNETCORE')), 'v9.0', null())]",
+                      "alwaysOn": "[not(equals(parameters('skuName'), 'F1'))]",
+                      "ftpsState": "Disabled",
+                      "minTlsVersion": "1.2",
+                      "http20Enabled": true
+                    }
+                  },
+                  "appInsightResourceId": "[if(parameters('enableApplicationInsights'), createObject('value', resourceId('Microsoft.Insights/components', variables('appInsightsName'))), createObject('value', null()))]",
+                  "slots": {
+                    "value": [
+                      {
+                        "name": "broken",
+                        "siteConfig": {
+                          "linuxFxVersion": "[if(variables('isLinux'), parameters('runtimeStack'), null())]",
+                          "netFrameworkVersion": "[if(and(not(variables('isLinux')), contains(parameters('runtimeStack'), 'DOTNETCORE')), 'v9.0', null())]",
+                          "alwaysOn": "[not(equals(parameters('skuName'), 'F1'))]",
+                          "ftpsState": "Disabled",
+                          "minTlsVersion": "1.2",
+                          "http20Enabled": true
+                        }
+                      }
+                    ]
+                  },
+                  "basicPublishingCredentialsPolicies": {
+                    "value": [
+                      {
+                        "name": "ftp",
+                        "allow": false
+                      },
+                      {
+                        "name": "scm",
+                        "allow": true
+                      }
+                    ]
+                  },
+                  "diagnosticSettings": "[if(not(empty(parameters('logAnalyticsWorkspaceId'))), createObject('value', createArray(createObject('workspaceResourceId', parameters('logAnalyticsWorkspaceId'), 'logCategoriesAndGroups', createArray(createObject('categoryGroup', 'allLogs')), 'metricCategories', createArray(createObject('category', 'AllMetrics'))))), createObject('value', createArray()))]"
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.93.31351",
+                      "templateHash": "17021074205285502384"
+                    },
+                    "name": "Web/Function Apps",
+                    "description": "This module deploys a Web or Function App."
+                  },
+                  "definitions": {
+                    "_1.privateEndpointCustomDnsConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "fqdn": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. FQDN that resolves to private endpoint IP address."
+                          }
+                        },
+                        "ipAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of private IP addresses of the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointIpConfigurationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the resource that is unique within a resource group."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "properties": {
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "memberName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "privateIPAddress": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. Properties of private endpoint IP configurations."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointPrivateDnsZoneGroupType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private DNS Zone Group."
+                          }
+                        },
+                        "privateDnsZoneGroupConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. The name of the private DNS Zone Group config."
+                                }
+                              },
+                              "privateDnsZoneResourceId": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. The resource id of the private DNS zone."
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "diagnosticSettingFullType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the diagnostic setting."
+                          }
+                        },
+                        "logCategoriesAndGroups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                                }
+                              },
+                              "categoryGroup": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                          }
+                        },
+                        "metricCategories": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                          }
+                        },
+                        "logAnalyticsDestinationType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "AzureDiagnostics",
+                            "Dedicated"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                          }
+                        },
+                        "workspaceResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "storageAccountResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "eventHubAuthorizationRuleResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                          }
+                        },
+                        "eventHubName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "marketplacePartnerResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "managedIdentityAllType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        },
+                        "userAssignedResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "privateEndpointSingleServiceType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private Endpoint."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The location to deploy the Private Endpoint to."
+                          }
+                        },
+                        "privateLinkServiceConnectionName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the private link connection to create."
+                          }
+                        },
+                        "service": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                          }
+                        },
+                        "subnetResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                          }
+                        },
+                        "resourceGroupResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                          }
+                        },
+                        "privateDnsZoneGroup": {
+                          "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                          }
+                        },
+                        "isManualConnection": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. If Manual Private Link Connection is required."
+                          }
+                        },
+                        "manualConnectionRequestMessage": {
+                          "type": "string",
+                          "nullable": true,
+                          "maxLength": 140,
+                          "metadata": {
+                            "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                          }
+                        },
+                        "customDnsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Custom DNS configurations."
+                          }
+                        },
+                        "ipConfigurations": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                          }
+                        },
+                        "applicationSecurityGroupResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                          }
+                        },
+                        "customNetworkInterfaceName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                          }
+                        },
+                        "lock": {
+                          "$ref": "#/definitions/lockType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "roleAssignments": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/roleAssignmentType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Array of role assignments to create."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                          }
+                        },
+                        "enableTelemetry": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enable/Disable usage telemetry for module."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Name of the site."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all Resources."
+                      }
+                    },
+                    "kind": {
+                      "type": "string",
+                      "allowedValues": [
+                        "functionapp",
+                        "functionapp,linux",
+                        "functionapp,workflowapp",
+                        "functionapp,workflowapp,linux",
+                        "functionapp,linux,container",
+                        "functionapp,linux,container,azurecontainerapps",
+                        "app,linux",
+                        "app",
+                        "linux,api",
+                        "api",
+                        "app,linux,container",
+                        "app,container,windows"
+                      ],
+                      "metadata": {
+                        "description": "Required. Type of site to deploy."
+                      }
+                    },
+                    "serverFarmResourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the app service plan to use for the site."
+                      }
+                    },
+                    "managedEnvironmentId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Azure Resource Manager ID of the customers selected Managed Environment on which to host this app."
+                      }
+                    },
+                    "httpsOnly": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Configures a site to accept only HTTPS requests. Issues redirect for HTTP requests."
+                      }
+                    },
+                    "clientAffinityEnabled": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. If client affinity is enabled."
+                      }
+                    },
+                    "appServiceEnvironmentResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The resource ID of the app service environment to use for this resource."
+                      }
+                    },
+                    "managedIdentities": {
+                      "$ref": "#/definitions/managedIdentityAllType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The managed identity definition for this resource."
+                      }
+                    },
+                    "keyVaultAccessIdentityResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The resource ID of the assigned identity to be used to access a key vault with."
+                      }
+                    },
+                    "storageAccountRequired": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Checks if Customer provided storage account is required."
+                      }
+                    },
+                    "virtualNetworkSubnetId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Azure Resource Manager ID of the Virtual network and subnet to be joined by Regional VNET Integration. This must be of the form /subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}."
+                      }
+                    },
+                    "vnetContentShareEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. To enable accessing content over virtual network."
+                      }
+                    },
+                    "vnetImagePullEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. To enable pulling image over Virtual Network."
+                      }
+                    },
+                    "vnetRouteAllEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied."
+                      }
+                    },
+                    "scmSiteAlsoStopped": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Stop SCM (KUDU) site when the app is stopped."
+                      }
+                    },
+                    "siteConfig": {
+                      "type": "object",
+                      "defaultValue": {
+                        "alwaysOn": true,
+                        "minTlsVersion": "1.2",
+                        "ftpsState": "FtpsOnly"
+                      },
+                      "metadata": {
+                        "description": "Optional. The site config object. The defaults are set to the following values: alwaysOn: true, minTlsVersion: '1.2', ftpsState: 'FtpsOnly'."
+                      }
+                    },
+                    "functionAppConfig": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The Function App configuration object."
+                      }
+                    },
+                    "storageAccountResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Required if app of kind functionapp. Resource ID of the storage account to manage triggers and logging function executions."
+                      }
+                    },
+                    "storageAccountUseIdentityAuthentication": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. If the provided storage account requires Identity based authentication ('allowSharedKeyAccess' is set to false). When set to true, the minimum role assignment required for the App Service Managed Identity to the storage account is 'Storage Blob Data Owner'."
+                      }
+                    },
+                    "webConfiguration": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The Site Config, Web settings to deploy."
+                      }
+                    },
+                    "msDeployConfiguration": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The extension MSDeployment configuration."
+                      }
+                    },
+                    "appInsightResourceId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Resource ID of the app insight to leverage for this resource."
+                      }
+                    },
+                    "appSettingsKeyValuePairs": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The app settings-value pairs except for AzureWebJobsStorage, AzureWebJobsDashboard, APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING."
+                      }
+                    },
+                    "authSettingV2Configuration": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The auth settings V2 configuration."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "logsConfiguration": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The logs settings configuration."
+                      }
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateEndpointSingleServiceType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible."
+                      }
+                    },
+                    "slots": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Configuration for deployment slots for an app."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "diagnosticSettings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/diagnosticSettingFullType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The diagnostic settings of the service."
+                      }
+                    },
+                    "clientCertEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. To enable client certificate authentication (TLS mutual authentication)."
+                      }
+                    },
+                    "clientCertExclusionPaths": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Client certificate authentication comma-separated exclusion paths."
+                      }
+                    },
+                    "clientCertMode": {
+                      "type": "string",
+                      "defaultValue": "Optional",
+                      "allowedValues": [
+                        "Optional",
+                        "OptionalInteractiveUser",
+                        "Required"
+                      ],
+                      "metadata": {
+                        "description": "Optional. This composes with ClientCertEnabled setting.\n- ClientCertEnabled=false means ClientCert is ignored.\n- ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.\n- ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.\n"
+                      }
+                    },
+                    "cloningInfo": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. If specified during app creation, the app is cloned from a source app."
+                      }
+                    },
+                    "containerSize": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Size of the function container."
+                      }
+                    },
+                    "dailyMemoryTimeQuota": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Maximum allowed daily memory-time quota (applicable on dynamic apps only)."
+                      }
+                    },
+                    "enabled": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Setting this value to false disables the app (takes the app offline)."
+                      }
+                    },
+                    "hostNameSslStates": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Hostname SSL states are used to manage the SSL bindings for app's hostnames."
+                      }
+                    },
+                    "hyperV": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Hyper-V sandbox."
+                      }
+                    },
+                    "redundancyMode": {
+                      "type": "string",
+                      "defaultValue": "None",
+                      "allowedValues": [
+                        "ActiveActive",
+                        "Failover",
+                        "GeoRedundant",
+                        "Manual",
+                        "None"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Site redundancy mode."
+                      }
+                    },
+                    "basicPublishingCredentialsPolicies": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The site publishing credential policy names which are associated with the sites."
+                      }
+                    },
+                    "hybridConnectionRelays": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Names of hybrid connection relays to connect app with."
+                      }
+                    },
+                    "publicNetworkAccess": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Enabled",
+                        "Disabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set."
+                      }
+                    },
+                    "e2eEncryptionEnabled": {
+                      "type": "bool",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. End to End Encryption Setting."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+                    "builtInRoleNames": {
+                      "App Compliance Automation Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')]",
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                      "Web Plan Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')]",
+                      "Website Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('46d3xbcp.res.web-site.{0}.{1}', replace('0.13.3', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "app": {
+                      "type": "Microsoft.Web/sites",
+                      "apiVersion": "2024-04-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "kind": "[parameters('kind')]",
+                      "tags": "[parameters('tags')]",
+                      "identity": "[variables('identity')]",
+                      "properties": {
+                        "managedEnvironmentId": "[if(not(empty(parameters('managedEnvironmentId'))), parameters('managedEnvironmentId'), null())]",
+                        "serverFarmId": "[parameters('serverFarmResourceId')]",
+                        "clientAffinityEnabled": "[parameters('clientAffinityEnabled')]",
+                        "httpsOnly": "[parameters('httpsOnly')]",
+                        "hostingEnvironmentProfile": "[if(not(empty(parameters('appServiceEnvironmentResourceId'))), createObject('id', parameters('appServiceEnvironmentResourceId')), null())]",
+                        "storageAccountRequired": "[parameters('storageAccountRequired')]",
+                        "keyVaultReferenceIdentity": "[parameters('keyVaultAccessIdentityResourceId')]",
+                        "virtualNetworkSubnetId": "[parameters('virtualNetworkSubnetId')]",
+                        "siteConfig": "[parameters('siteConfig')]",
+                        "functionAppConfig": "[parameters('functionAppConfig')]",
+                        "clientCertEnabled": "[parameters('clientCertEnabled')]",
+                        "clientCertExclusionPaths": "[parameters('clientCertExclusionPaths')]",
+                        "clientCertMode": "[parameters('clientCertMode')]",
+                        "cloningInfo": "[parameters('cloningInfo')]",
+                        "containerSize": "[parameters('containerSize')]",
+                        "dailyMemoryTimeQuota": "[parameters('dailyMemoryTimeQuota')]",
+                        "enabled": "[parameters('enabled')]",
+                        "hostNameSslStates": "[parameters('hostNameSslStates')]",
+                        "hyperV": "[parameters('hyperV')]",
+                        "redundancyMode": "[parameters('redundancyMode')]",
+                        "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(not(empty(parameters('privateEndpoints'))), 'Disabled', 'Enabled'))]",
+                        "vnetContentShareEnabled": "[parameters('vnetContentShareEnabled')]",
+                        "vnetImagePullEnabled": "[parameters('vnetImagePullEnabled')]",
+                        "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                        "scmSiteAlsoStopped": "[parameters('scmSiteAlsoStopped')]",
+                        "endToEndEncryptionEnabled": "[parameters('e2eEncryptionEnabled')]"
+                      }
+                    },
+                    "app_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_diagnosticSettings": {
+                      "copy": {
+                        "name": "app_diagnosticSettings",
+                        "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                      },
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2021-05-01-preview",
+                      "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "metrics",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                            "input": {
+                              "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                              "timeGrain": null
+                            }
+                          },
+                          {
+                            "name": "logs",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs'))))]",
+                            "input": {
+                              "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'categoryGroup')]",
+                              "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'category')]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'enabled'), true())]"
+                            }
+                          }
+                        ],
+                        "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                        "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                        "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                        "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                        "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                        "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_roleAssignments": {
+                      "copy": {
+                        "name": "app_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Web/sites', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_appsettings": {
+                      "condition": "[or(or(not(empty(parameters('appSettingsKeyValuePairs'))), not(empty(parameters('appInsightResourceId')))), not(empty(parameters('storageAccountResourceId'))))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Config-AppSettings', uniqueString(deployment().name, parameters('location')))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "kind": {
+                            "value": "[parameters('kind')]"
+                          },
+                          "storageAccountResourceId": {
+                            "value": "[parameters('storageAccountResourceId')]"
+                          },
+                          "storageAccountUseIdentityAuthentication": {
+                            "value": "[parameters('storageAccountUseIdentityAuthentication')]"
+                          },
+                          "appInsightResourceId": {
+                            "value": "[parameters('appInsightResourceId')]"
+                          },
+                          "appSettingsKeyValuePairs": {
+                            "value": "[parameters('appSettingsKeyValuePairs')]"
+                          },
+                          "currentAppSettings": "[if(not(empty(resourceId('Microsoft.Web/sites', parameters('name')))), createObject('value', list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('name'))), '2023-12-01').properties), createObject('value', createObject()))]"
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "10907400404924884098"
+                            },
+                            "name": "Site App Settings",
+                            "description": "This module deploys a Site App Setting."
+                          },
+                          "parameters": {
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent site resource. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "kind": {
+                              "type": "string",
+                              "allowedValues": [
+                                "functionapp",
+                                "functionapp,linux",
+                                "functionapp,workflowapp",
+                                "functionapp,workflowapp,linux",
+                                "functionapp,linux,container",
+                                "functionapp,linux,container,azurecontainerapps",
+                                "app,linux",
+                                "app",
+                                "linux,api",
+                                "api",
+                                "app,linux,container",
+                                "app,container,windows"
+                              ],
+                              "metadata": {
+                                "description": "Required. Type of site to deploy."
+                              }
+                            },
+                            "storageAccountResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Required if app of kind functionapp. Resource ID of the storage account to manage triggers and logging function executions."
+                              }
+                            },
+                            "storageAccountUseIdentityAuthentication": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. If the provided storage account requires Identity based authentication ('allowSharedKeyAccess' is set to false). When set to true, the minimum role assignment required for the App Service Managed Identity to the storage account is 'Storage Blob Data Owner'."
+                              }
+                            },
+                            "appInsightResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Resource ID of the app insight to leverage for this resource."
+                              }
+                            },
+                            "appSettingsKeyValuePairs": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The app settings key-value pairs except for AzureWebJobsStorage, AzureWebJobsDashboard, APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING."
+                              }
+                            },
+                            "currentAppSettings": {
+                              "type": "object",
+                              "defaultValue": {},
+                              "metadata": {
+                                "description": "Optional. The current app settings."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "app": {
+                              "existing": true,
+                              "type": "Microsoft.Web/sites",
+                              "apiVersion": "2023-12-01",
+                              "name": "[parameters('appName')]"
+                            },
+                            "appInsight": {
+                              "condition": "[not(empty(parameters('appInsightResourceId')))]",
+                              "existing": true,
+                              "type": "Microsoft.Insights/components",
+                              "apiVersion": "2020-02-02",
+                              "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+                              "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+                              "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
+                            },
+                            "storageAccount": {
+                              "condition": "[not(empty(parameters('storageAccountResourceId')))]",
+                              "existing": true,
+                              "type": "Microsoft.Storage/storageAccounts",
+                              "apiVersion": "2023-05-01",
+                              "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+                              "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+                              "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
+                            },
+                            "appSettings": {
+                              "type": "Microsoft.Web/sites/config",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), 'appsettings')]",
+                              "kind": "[parameters('kind')]",
+                              "properties": "[union(coalesce(parameters('currentAppSettings'), createObject()), coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('storageAccountUseIdentityAuthentication'))), createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-05-01').keys[0].value, environment().suffixes.storage)), if(and(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountUseIdentityAuthentication')), union(createObject('AzureWebJobsStorage__accountName', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), createObject('AzureWebJobsStorage__blobServiceUri', reference('storageAccount').primaryEndpoints.blob), createObject('AzureWebJobsStorage__queueServiceUri', reference('storageAccount').primaryEndpoints.queue), createObject('AzureWebJobsStorage__tableServiceUri', reference('storageAccount').primaryEndpoints.table)), createObject())), if(not(empty(parameters('appInsightResourceId'))), createObject('APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+                              "dependsOn": [
+                                "appInsight",
+                                "storageAccount"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the site config."
+                              },
+                              "value": "appsettings"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the site config."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'appsettings')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the site config was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_authsettingsv2": {
+                      "condition": "[not(empty(parameters('authSettingV2Configuration')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Config-AuthSettingsV2', uniqueString(deployment().name, parameters('location')))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "kind": {
+                            "value": "[parameters('kind')]"
+                          },
+                          "authSettingV2Configuration": {
+                            "value": "[coalesce(parameters('authSettingV2Configuration'), createObject())]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "1129994114817101549"
+                            },
+                            "name": "Site Auth Settings V2 Config",
+                            "description": "This module deploys a Site Auth Settings V2 Configuration."
+                          },
+                          "parameters": {
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent site resource. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "kind": {
+                              "type": "string",
+                              "allowedValues": [
+                                "functionapp",
+                                "functionapp,linux",
+                                "functionapp,workflowapp",
+                                "functionapp,workflowapp,linux",
+                                "functionapp,linux,container",
+                                "functionapp,linux,container,azurecontainerapps",
+                                "app,linux",
+                                "app",
+                                "linux,api",
+                                "api",
+                                "app,linux,container",
+                                "app,container,windows"
+                              ],
+                              "metadata": {
+                                "description": "Required. Type of site to deploy."
+                              }
+                            },
+                            "authSettingV2Configuration": {
+                              "type": "object",
+                              "metadata": {
+                                "description": "Required. The auth settings V2 configuration."
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Web/sites/config",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), 'authsettingsV2')]",
+                              "kind": "[parameters('kind')]",
+                              "properties": "[parameters('authSettingV2Configuration')]"
+                            }
+                          ],
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the site config."
+                              },
+                              "value": "authsettingsV2"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the site config."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'authsettingsV2')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the site config was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_logssettings": {
+                      "condition": "[not(empty(coalesce(parameters('logsConfiguration'), createObject())))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Config-Logs', uniqueString(deployment().name, parameters('location')))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "logsConfiguration": {
+                            "value": "[parameters('logsConfiguration')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "17967336872376441757"
+                            },
+                            "name": "Site logs Config",
+                            "description": "This module deploys a Site logs Configuration."
+                          },
+                          "parameters": {
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the parent site resource."
+                              }
+                            },
+                            "logsConfiguration": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The logs settings configuration."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "app": {
+                              "existing": true,
+                              "type": "Microsoft.Web/sites",
+                              "apiVersion": "2024-04-01",
+                              "name": "[parameters('appName')]"
+                            },
+                            "webSettings": {
+                              "type": "Microsoft.Web/sites/config",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), 'logs')]",
+                              "kind": "string",
+                              "properties": "[parameters('logsConfiguration')]"
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the site config."
+                              },
+                              "value": "logs"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the site config."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'logs')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the site config was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app",
+                        "app_appsettings"
+                      ]
+                    },
+                    "app_websettings": {
+                      "condition": "[not(empty(coalesce(parameters('webConfiguration'), createObject())))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Config-Web', uniqueString(deployment().name, parameters('location')))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "webConfiguration": {
+                            "value": "[parameters('webConfiguration')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "15058680643544097487"
+                            },
+                            "name": "Site Web Config",
+                            "description": "This module deploys web settings configuration available under sites/config name: web."
+                          },
+                          "parameters": {
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the parent site resource."
+                              }
+                            },
+                            "webConfiguration": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The Site Config, Web settings to deploy."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "app": {
+                              "existing": true,
+                              "type": "Microsoft.Web/sites",
+                              "apiVersion": "2024-04-01",
+                              "name": "[parameters('appName')]"
+                            },
+                            "webSettings": {
+                              "type": "Microsoft.Web/sites/config",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), 'web')]",
+                              "kind": "string",
+                              "properties": "[parameters('webConfiguration')]"
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the site config."
+                              },
+                              "value": "web"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the site config."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'web')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the site config was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "extension_msdeploy": {
+                      "condition": "[not(empty(parameters('msDeployConfiguration')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Extension-MSDeploy', uniqueString(deployment().name, parameters('location')))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "msDeployConfiguration": {
+                            "value": "[coalesce(parameters('msDeployConfiguration'), createObject())]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "14895622660217616811"
+                            },
+                            "name": "Site Deployment Extension ",
+                            "description": "This module deploys a Site extension for MSDeploy."
+                          },
+                          "parameters": {
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the parent site resource."
+                              }
+                            },
+                            "msDeployConfiguration": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Sets the MSDeployment Properties."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "app": {
+                              "existing": true,
+                              "type": "Microsoft.Web/sites",
+                              "apiVersion": "2024-04-01",
+                              "name": "[parameters('appName')]"
+                            },
+                            "msdeploy": {
+                              "type": "Microsoft.Web/sites/extensions",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), 'MSDeploy')]",
+                              "kind": "MSDeploy",
+                              "properties": "[parameters('msDeployConfiguration')]"
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the MSDeploy Package."
+                              },
+                              "value": "MSDeploy"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Site Extension."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/extensions', parameters('appName'), 'MSDeploy')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the site config was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_slots": {
+                      "copy": {
+                        "name": "app_slots",
+                        "count": "[length(coalesce(parameters('slots'), createArray()))]",
+                        "mode": "serial",
+                        "batchSize": 1
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Slot-{1}', uniqueString(deployment().name, parameters('location')), coalesce(parameters('slots'), createArray())[copyIndex()].name)]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('slots'), createArray())[copyIndex()].name]"
+                          },
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[parameters('location')]"
+                          },
+                          "kind": {
+                            "value": "[parameters('kind')]"
+                          },
+                          "serverFarmResourceId": {
+                            "value": "[parameters('serverFarmResourceId')]"
+                          },
+                          "httpsOnly": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'httpsOnly'), parameters('httpsOnly'))]"
+                          },
+                          "appServiceEnvironmentResourceId": {
+                            "value": "[parameters('appServiceEnvironmentResourceId')]"
+                          },
+                          "clientAffinityEnabled": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'clientAffinityEnabled'), parameters('clientAffinityEnabled'))]"
+                          },
+                          "managedIdentities": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'managedIdentities'), parameters('managedIdentities'))]"
+                          },
+                          "keyVaultAccessIdentityResourceId": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'keyVaultAccessIdentityResourceId'), parameters('keyVaultAccessIdentityResourceId'))]"
+                          },
+                          "storageAccountRequired": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'storageAccountRequired'), parameters('storageAccountRequired'))]"
+                          },
+                          "virtualNetworkSubnetId": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'virtualNetworkSubnetId'), parameters('virtualNetworkSubnetId'))]"
+                          },
+                          "siteConfig": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'siteConfig'), parameters('siteConfig'))]"
+                          },
+                          "functionAppConfig": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'functionAppConfig'), parameters('functionAppConfig'))]"
+                          },
+                          "storageAccountResourceId": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'storageAccountResourceId'), parameters('storageAccountResourceId'))]"
+                          },
+                          "storageAccountUseIdentityAuthentication": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'storageAccountUseIdentityAuthentication'), parameters('storageAccountUseIdentityAuthentication'))]"
+                          },
+                          "appInsightResourceId": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'appInsightResourceId'), parameters('appInsightResourceId'))]"
+                          },
+                          "authSettingV2Configuration": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'authSettingV2Configuration'), parameters('authSettingV2Configuration'))]"
+                          },
+                          "msDeployConfiguration": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'msDeployConfiguration'), parameters('msDeployConfiguration'))]"
+                          },
+                          "diagnosticSettings": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'diagnosticSettings')]"
+                          },
+                          "roleAssignments": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'roleAssignments')]"
+                          },
+                          "appSettingsKeyValuePairs": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'appSettingsKeyValuePairs'), parameters('appSettingsKeyValuePairs'))]"
+                          },
+                          "basicPublishingCredentialsPolicies": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'basicPublishingCredentialsPolicies'), parameters('basicPublishingCredentialsPolicies'))]"
+                          },
+                          "lock": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                          },
+                          "privateEndpoints": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'privateEndpoints'), createArray())]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "clientCertEnabled": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'clientCertEnabled')]"
+                          },
+                          "clientCertExclusionPaths": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'clientCertExclusionPaths')]"
+                          },
+                          "clientCertMode": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'clientCertMode')]"
+                          },
+                          "cloningInfo": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'cloningInfo')]"
+                          },
+                          "containerSize": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'containerSize')]"
+                          },
+                          "customDomainVerificationId": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'customDomainVerificationId')]"
+                          },
+                          "dailyMemoryTimeQuota": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'dailyMemoryTimeQuota')]"
+                          },
+                          "enabled": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'enabled')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                          },
+                          "hostNameSslStates": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'hostNameSslStates')]"
+                          },
+                          "hyperV": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'hyperV')]"
+                          },
+                          "publicNetworkAccess": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'publicNetworkAccess'), if(or(not(empty(tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'privateEndpoints'))), not(empty(parameters('privateEndpoints')))), 'Disabled', 'Enabled'))]"
+                          },
+                          "redundancyMode": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'redundancyMode')]"
+                          },
+                          "vnetContentShareEnabled": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'vnetContentShareEnabled')]"
+                          },
+                          "vnetImagePullEnabled": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'vnetImagePullEnabled')]"
+                          },
+                          "vnetRouteAllEnabled": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'vnetRouteAllEnabled')]"
+                          },
+                          "hybridConnectionRelays": {
+                            "value": "[tryGet(coalesce(parameters('slots'), createArray())[copyIndex()], 'hybridConnectionRelays')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "5688048494130523073"
+                            },
+                            "name": "Web/Function App Deployment Slots",
+                            "description": "This module deploys a Web or Function App Deployment Slot."
+                          },
+                          "definitions": {
+                            "_1.privateEndpointCustomDnsConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "fqdn": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                                  }
+                                },
+                                "ipAddresses": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. A list of private IP addresses of the private endpoint."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "_1.privateEndpointIpConfigurationType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the resource that is unique within a resource group."
+                                  }
+                                },
+                                "properties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "groupId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                                      }
+                                    },
+                                    "memberName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                                      }
+                                    },
+                                    "privateIPAddress": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. Properties of private endpoint IP configurations."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "_1.privateEndpointPrivateDnsZoneGroupType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private DNS Zone Group."
+                                  }
+                                },
+                                "privateDnsZoneGroupConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. The name of the private DNS Zone Group config."
+                                        }
+                                      },
+                                      "privateDnsZoneResourceId": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The resource id of the private DNS zone."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "diagnosticSettingFullType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the diagnostic setting."
+                                  }
+                                },
+                                "logCategoriesAndGroups": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "category": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                                        }
+                                      },
+                                      "categoryGroup": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                                        }
+                                      },
+                                      "enabled": {
+                                        "type": "bool",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                                  }
+                                },
+                                "metricCategories": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "category": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                        }
+                                      },
+                                      "enabled": {
+                                        "type": "bool",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                                  }
+                                },
+                                "logAnalyticsDestinationType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "AzureDiagnostics",
+                                    "Dedicated"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                                  }
+                                },
+                                "workspaceResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "storageAccountResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "eventHubAuthorizationRuleResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                                  }
+                                },
+                                "eventHubName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "marketplacePartnerResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "lockType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the name of lock."
+                                  }
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "CanNotDelete",
+                                    "None",
+                                    "ReadOnly"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a lock.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "managedIdentityAllType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                },
+                                "userAssignedResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "privateEndpointSingleServiceType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private Endpoint."
+                                  }
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The location to deploy the Private Endpoint to."
+                                  }
+                                },
+                                "privateLinkServiceConnectionName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private link connection to create."
+                                  }
+                                },
+                                "service": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                                  }
+                                },
+                                "subnetResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                                  }
+                                },
+                                "resourceGroupResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                                  }
+                                },
+                                "privateDnsZoneGroup": {
+                                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                                  }
+                                },
+                                "isManualConnection": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. If Manual Private Link Connection is required."
+                                  }
+                                },
+                                "manualConnectionRequestMessage": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 140,
+                                  "metadata": {
+                                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                                  }
+                                },
+                                "customDnsConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Custom DNS configurations."
+                                  }
+                                },
+                                "ipConfigurations": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                                  }
+                                },
+                                "applicationSecurityGroupResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                                  }
+                                },
+                                "customNetworkInterfaceName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                                  }
+                                },
+                                "lock": {
+                                  "$ref": "#/definitions/lockType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                },
+                                "roleAssignments": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/roleAssignmentType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Array of role assignments to create."
+                                  }
+                                },
+                                "tags": {
+                                  "type": "object",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                                  }
+                                },
+                                "enableTelemetry": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enable/Disable usage telemetry for module."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "roleAssignmentType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                  }
+                                },
+                                "roleDefinitionIdOrName": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                  }
+                                },
+                                "principalId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                  }
+                                },
+                                "principalType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "Device",
+                                    "ForeignGroup",
+                                    "Group",
+                                    "ServicePrincipal",
+                                    "User"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The principal type of the assigned principal ID."
+                                  }
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The description of the role assignment."
+                                  }
+                                },
+                                "condition": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                  }
+                                },
+                                "conditionVersion": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "2.0"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Version of the condition."
+                                  }
+                                },
+                                "delegatedManagedIdentityResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a role assignment.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Name of the slot."
+                              }
+                            },
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent site resource. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all Resources."
+                              }
+                            },
+                            "kind": {
+                              "type": "string",
+                              "allowedValues": [
+                                "functionapp",
+                                "functionapp,linux",
+                                "functionapp,workflowapp",
+                                "functionapp,workflowapp,linux",
+                                "functionapp,linux,container",
+                                "functionapp,linux,container,azurecontainerapps",
+                                "app,linux",
+                                "app",
+                                "linux,api",
+                                "api",
+                                "app,linux,container",
+                                "app,container,windows"
+                              ],
+                              "metadata": {
+                                "description": "Required. Type of site to deploy."
+                              }
+                            },
+                            "serverFarmResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The resource ID of the app service plan to use for the slot."
+                              }
+                            },
+                            "httpsOnly": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Configures a slot to accept only HTTPS requests. Issues redirect for HTTP requests."
+                              }
+                            },
+                            "clientAffinityEnabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. If client affinity is enabled."
+                              }
+                            },
+                            "appServiceEnvironmentResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The resource ID of the app service environment to use for this resource."
+                              }
+                            },
+                            "managedIdentities": {
+                              "$ref": "#/definitions/managedIdentityAllType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The managed identity definition for this resource."
+                              }
+                            },
+                            "keyVaultAccessIdentityResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The resource ID of the assigned identity to be used to access a key vault with."
+                              }
+                            },
+                            "storageAccountRequired": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Checks if Customer provided storage account is required."
+                              }
+                            },
+                            "virtualNetworkSubnetId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Azure Resource Manager ID of the Virtual network and subnet to be joined by Regional VNET Integration. This must be of the form /subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}."
+                              }
+                            },
+                            "siteConfig": {
+                              "type": "object",
+                              "defaultValue": {
+                                "alwaysOn": true
+                              },
+                              "metadata": {
+                                "description": "Optional. The site config object."
+                              }
+                            },
+                            "functionAppConfig": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The Function App config object."
+                              }
+                            },
+                            "storageAccountResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Required if app of kind functionapp. Resource ID of the storage account to manage triggers and logging function executions."
+                              }
+                            },
+                            "storageAccountUseIdentityAuthentication": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. If the provided storage account requires Identity based authentication ('allowSharedKeyAccess' is set to false). When set to true, the minimum role assignment required for the App Service Managed Identity to the storage account is 'Storage Blob Data Owner'."
+                              }
+                            },
+                            "appInsightResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Resource ID of the app insight to leverage for this resource."
+                              }
+                            },
+                            "appSettingsKeyValuePairs": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The app settings-value pairs except for AzureWebJobsStorage, AzureWebJobsDashboard, APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING."
+                              }
+                            },
+                            "authSettingV2Configuration": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The auth settings V2 configuration."
+                              }
+                            },
+                            "msDeployConfiguration": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The extension MSDeployment configuration."
+                              }
+                            },
+                            "lock": {
+                              "$ref": "#/definitions/lockType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The lock settings of the service."
+                              }
+                            },
+                            "privateEndpoints": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateEndpointSingleServiceType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Configuration details for private endpoints."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tags of the resource."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/roleAssignmentType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of role assignments to create."
+                              }
+                            },
+                            "diagnosticSettings": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/diagnosticSettingFullType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The diagnostic settings of the service."
+                              }
+                            },
+                            "clientCertEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. To enable client certificate authentication (TLS mutual authentication)."
+                              }
+                            },
+                            "clientCertExclusionPaths": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Client certificate authentication comma-separated exclusion paths."
+                              }
+                            },
+                            "clientCertMode": {
+                              "type": "string",
+                              "defaultValue": "Optional",
+                              "allowedValues": [
+                                "Optional",
+                                "OptionalInteractiveUser",
+                                "Required"
+                              ],
+                              "metadata": {
+                                "description": "Optional. This composes with ClientCertEnabled setting.</p>- ClientCertEnabled: false means ClientCert is ignored.</p>- ClientCertEnabled: true and ClientCertMode: Required means ClientCert is required.</p>- ClientCertEnabled: true and ClientCertMode: Optional means ClientCert is optional or accepted."
+                              }
+                            },
+                            "cloningInfo": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. If specified during app creation, the app is cloned from a source app."
+                              }
+                            },
+                            "containerSize": {
+                              "type": "int",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Size of the function container."
+                              }
+                            },
+                            "customDomainVerificationId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification."
+                              }
+                            },
+                            "dailyMemoryTimeQuota": {
+                              "type": "int",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Maximum allowed daily memory-time quota (applicable on dynamic apps only)."
+                              }
+                            },
+                            "enabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Setting this value to false disables the app (takes the app offline)."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            },
+                            "hostNameSslStates": {
+                              "type": "array",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Hostname SSL states are used to manage the SSL bindings for app's hostnames."
+                              }
+                            },
+                            "hyperV": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Hyper-V sandbox."
+                              }
+                            },
+                            "publicNetworkAccess": {
+                              "type": "string",
+                              "nullable": true,
+                              "allowedValues": [
+                                "Enabled",
+                                "Disabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Allow or block all public traffic."
+                              }
+                            },
+                            "redundancyMode": {
+                              "type": "string",
+                              "defaultValue": "None",
+                              "allowedValues": [
+                                "ActiveActive",
+                                "Failover",
+                                "GeoRedundant",
+                                "Manual",
+                                "None"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Site redundancy mode."
+                              }
+                            },
+                            "basicPublishingCredentialsPolicies": {
+                              "type": "array",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The site publishing credential policy names which are associated with the site slot."
+                              }
+                            },
+                            "vnetContentShareEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. To enable accessing content over virtual network."
+                              }
+                            },
+                            "vnetImagePullEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. To enable pulling image over Virtual Network."
+                              }
+                            },
+                            "vnetRouteAllEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied."
+                              }
+                            },
+                            "hybridConnectionRelays": {
+                              "type": "array",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Names of hybrid connection relays to connect app with."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "formattedRoleAssignments",
+                                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                              }
+                            ],
+                            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null())), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+                            "builtInRoleNames": {
+                              "App Compliance Automation Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')]",
+                              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                              "Web Plan Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')]",
+                              "Website Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]"
+                            }
+                          },
+                          "resources": {
+                            "app": {
+                              "existing": true,
+                              "type": "Microsoft.Web/sites",
+                              "apiVersion": "2024-04-01",
+                              "name": "[parameters('appName')]"
+                            },
+                            "slot": {
+                              "type": "Microsoft.Web/sites/slots",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('appName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "kind": "[parameters('kind')]",
+                              "tags": "[parameters('tags')]",
+                              "identity": "[variables('identity')]",
+                              "properties": {
+                                "serverFarmId": "[parameters('serverFarmResourceId')]",
+                                "clientAffinityEnabled": "[parameters('clientAffinityEnabled')]",
+                                "httpsOnly": "[parameters('httpsOnly')]",
+                                "hostingEnvironmentProfile": "[if(not(empty(parameters('appServiceEnvironmentResourceId'))), createObject('id', parameters('appServiceEnvironmentResourceId')), null())]",
+                                "storageAccountRequired": "[parameters('storageAccountRequired')]",
+                                "keyVaultReferenceIdentity": "[parameters('keyVaultAccessIdentityResourceId')]",
+                                "virtualNetworkSubnetId": "[parameters('virtualNetworkSubnetId')]",
+                                "siteConfig": "[parameters('siteConfig')]",
+                                "functionAppConfig": "[parameters('functionAppConfig')]",
+                                "clientCertEnabled": "[parameters('clientCertEnabled')]",
+                                "clientCertExclusionPaths": "[parameters('clientCertExclusionPaths')]",
+                                "clientCertMode": "[parameters('clientCertMode')]",
+                                "cloningInfo": "[parameters('cloningInfo')]",
+                                "containerSize": "[parameters('containerSize')]",
+                                "customDomainVerificationId": "[parameters('customDomainVerificationId')]",
+                                "dailyMemoryTimeQuota": "[parameters('dailyMemoryTimeQuota')]",
+                                "enabled": "[parameters('enabled')]",
+                                "hostNameSslStates": "[parameters('hostNameSslStates')]",
+                                "hyperV": "[parameters('hyperV')]",
+                                "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
+                                "redundancyMode": "[parameters('redundancyMode')]",
+                                "vnetContentShareEnabled": "[parameters('vnetContentShareEnabled')]",
+                                "vnetImagePullEnabled": "[parameters('vnetImagePullEnabled')]",
+                                "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                              }
+                            },
+                            "slot_lock": {
+                              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                              "type": "Microsoft.Authorization/locks",
+                              "apiVersion": "2020-05-01",
+                              "scope": "[format('Microsoft.Web/sites/{0}/slots/{1}', parameters('appName'), parameters('name'))]",
+                              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                              "properties": {
+                                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_diagnosticSettings": {
+                              "copy": {
+                                "name": "slot_diagnosticSettings",
+                                "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                              },
+                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "apiVersion": "2021-05-01-preview",
+                              "scope": "[format('Microsoft.Web/sites/{0}/slots/{1}', parameters('appName'), parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "metrics",
+                                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                                    "input": {
+                                      "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                                      "timeGrain": null
+                                    }
+                                  },
+                                  {
+                                    "name": "logs",
+                                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs'))))]",
+                                    "input": {
+                                      "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'categoryGroup')]",
+                                      "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'category')]",
+                                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'enabled'), true())]"
+                                    }
+                                  }
+                                ],
+                                "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                                "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                                "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                                "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                                "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                                "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_roleAssignments": {
+                              "copy": {
+                                "name": "slot_roleAssignments",
+                                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                              },
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "scope": "[format('Microsoft.Web/sites/{0}/slots/{1}', parameters('appName'), parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Web/sites/slots', parameters('appName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                              "properties": {
+                                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_appsettings": {
+                              "condition": "[or(or(not(empty(parameters('appSettingsKeyValuePairs'))), not(empty(parameters('appInsightResourceId')))), not(empty(parameters('storageAccountResourceId'))))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-Slot-{1}-Config-AppSettings', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "slotName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "appName": {
+                                    "value": "[parameters('appName')]"
+                                  },
+                                  "kind": {
+                                    "value": "[parameters('kind')]"
+                                  },
+                                  "storageAccountResourceId": {
+                                    "value": "[parameters('storageAccountResourceId')]"
+                                  },
+                                  "storageAccountUseIdentityAuthentication": {
+                                    "value": "[parameters('storageAccountUseIdentityAuthentication')]"
+                                  },
+                                  "appInsightResourceId": {
+                                    "value": "[parameters('appInsightResourceId')]"
+                                  },
+                                  "appSettingsKeyValuePairs": {
+                                    "value": "[parameters('appSettingsKeyValuePairs')]"
+                                  },
+                                  "currentAppSettings": "[if(not(empty(resourceId('Microsoft.Web/sites/slots', parameters('appName'), parameters('name')))), createObject('value', list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites/slots', parameters('appName'), parameters('name'))), '2023-12-01').properties), createObject('value', createObject()))]"
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "9869757473830929279"
+                                    },
+                                    "name": "Site Slot App Settings",
+                                    "description": "This module deploys a Site Slot App Setting."
+                                  },
+                                  "parameters": {
+                                    "slotName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Slot name to be configured."
+                                      }
+                                    },
+                                    "appName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent site resource. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "kind": {
+                                      "type": "string",
+                                      "allowedValues": [
+                                        "functionapp",
+                                        "functionapp,linux",
+                                        "functionapp,workflowapp",
+                                        "functionapp,workflowapp,linux",
+                                        "functionapp,linux,container",
+                                        "functionapp,linux,container,azurecontainerapps",
+                                        "app,linux",
+                                        "app",
+                                        "linux,api",
+                                        "api",
+                                        "app,linux,container",
+                                        "app,container,windows"
+                                      ],
+                                      "metadata": {
+                                        "description": "Required. Type of site to deploy."
+                                      }
+                                    },
+                                    "storageAccountResourceId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Required if app of kind functionapp. Resource ID of the storage account to manage triggers and logging function executions."
+                                      }
+                                    },
+                                    "storageAccountUseIdentityAuthentication": {
+                                      "type": "bool",
+                                      "defaultValue": false,
+                                      "metadata": {
+                                        "description": "Optional. If the provided storage account requires Identity based authentication ('allowSharedKeyAccess' is set to false). When set to true, the minimum role assignment required for the App Service Managed Identity to the storage account is 'Storage Blob Data Owner'."
+                                      }
+                                    },
+                                    "appInsightResourceId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Resource ID of the app insight to leverage for this resource."
+                                      }
+                                    },
+                                    "appSettingsKeyValuePairs": {
+                                      "type": "object",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The app settings key-value pairs except for AzureWebJobsStorage, AzureWebJobsDashboard, APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING."
+                                      }
+                                    },
+                                    "currentAppSettings": {
+                                      "type": "object",
+                                      "defaultValue": {},
+                                      "metadata": {
+                                        "description": "Optional. The current app settings."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "app::slot": {
+                                      "existing": true,
+                                      "type": "Microsoft.Web/sites/slots",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}', parameters('appName'), parameters('slotName'))]"
+                                    },
+                                    "app": {
+                                      "existing": true,
+                                      "type": "Microsoft.Web/sites",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[parameters('appName')]"
+                                    },
+                                    "appInsight": {
+                                      "condition": "[not(empty(parameters('appInsightResourceId')))]",
+                                      "existing": true,
+                                      "type": "Microsoft.Insights/components",
+                                      "apiVersion": "2020-02-02",
+                                      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+                                      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+                                      "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
+                                    },
+                                    "storageAccount": {
+                                      "condition": "[not(empty(parameters('storageAccountResourceId')))]",
+                                      "existing": true,
+                                      "type": "Microsoft.Storage/storageAccounts",
+                                      "apiVersion": "2023-05-01",
+                                      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+                                      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+                                      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
+                                    },
+                                    "slotSettings": {
+                                      "type": "Microsoft.Web/sites/slots/config",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), 'appsettings')]",
+                                      "kind": "[parameters('kind')]",
+                                      "properties": "[union(coalesce(parameters('currentAppSettings'), createObject()), coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('storageAccountUseIdentityAuthentication'))), createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-05-01').keys[0].value, environment().suffixes.storage)), if(and(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountUseIdentityAuthentication')), union(createObject('AzureWebJobsStorage__accountName', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), createObject('AzureWebJobsStorage__blobServiceUri', reference('storageAccount').primaryEndpoints.blob)), createObject())), if(not(empty(parameters('appInsightResourceId'))), createObject('APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+                                      "dependsOn": [
+                                        "appInsight",
+                                        "storageAccount"
+                                      ]
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the slot config."
+                                      },
+                                      "value": "appsettings"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the slot config."
+                                      },
+                                      "value": "[resourceId('Microsoft.Web/sites/slots/config', parameters('appName'), parameters('slotName'), 'appsettings')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the slot config was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_authsettingsv2": {
+                              "condition": "[not(empty(parameters('authSettingV2Configuration')))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-Slot-{1}-Config-AuthSettingsV2', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "slotName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "appName": {
+                                    "value": "[parameters('appName')]"
+                                  },
+                                  "kind": {
+                                    "value": "[parameters('kind')]"
+                                  },
+                                  "authSettingV2Configuration": {
+                                    "value": "[coalesce(parameters('authSettingV2Configuration'), createObject())]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "4602741618711602070"
+                                    },
+                                    "name": "Site Slot Auth Settings V2 Config",
+                                    "description": "This module deploys a Site Auth Settings V2 Configuration."
+                                  },
+                                  "parameters": {
+                                    "appName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent site resource. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "slotName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Slot name to be configured."
+                                      }
+                                    },
+                                    "kind": {
+                                      "type": "string",
+                                      "allowedValues": [
+                                        "functionapp",
+                                        "functionapp,linux",
+                                        "functionapp,workflowapp",
+                                        "functionapp,workflowapp,linux",
+                                        "functionapp,linux,container",
+                                        "functionapp,linux,container,azurecontainerapps",
+                                        "app,linux",
+                                        "app",
+                                        "linux,api",
+                                        "api",
+                                        "app,linux,container",
+                                        "app,container,windows"
+                                      ],
+                                      "metadata": {
+                                        "description": "Required. Type of site to deploy."
+                                      }
+                                    },
+                                    "authSettingV2Configuration": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "description": "Required. The auth settings V2 configuration."
+                                      }
+                                    }
+                                  },
+                                  "resources": [
+                                    {
+                                      "type": "Microsoft.Web/sites/slots/config",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), 'authsettingsV2')]",
+                                      "kind": "[parameters('kind')]",
+                                      "properties": "[parameters('authSettingV2Configuration')]"
+                                    }
+                                  ],
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the slot config."
+                                      },
+                                      "value": "authsettingsV2"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the slot config."
+                                      },
+                                      "value": "[resourceId('Microsoft.Web/sites/slots/config', parameters('appName'), parameters('slotName'), 'authsettingsV2')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the slot config was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_basicPublishingCredentialsPolicies": {
+                              "copy": {
+                                "name": "slot_basicPublishingCredentialsPolicies",
+                                "count": "[length(coalesce(parameters('basicPublishingCredentialsPolicies'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-Slot-Publish-Cred-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "appName": {
+                                    "value": "[parameters('appName')]"
+                                  },
+                                  "slotName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "name": {
+                                    "value": "[coalesce(parameters('basicPublishingCredentialsPolicies'), createArray())[copyIndex()].name]"
+                                  },
+                                  "allow": {
+                                    "value": "[tryGet(coalesce(parameters('basicPublishingCredentialsPolicies'), createArray())[copyIndex()], 'allow')]"
+                                  },
+                                  "location": {
+                                    "value": "[parameters('location')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "8803130402255189673"
+                                    },
+                                    "name": "Web Site Slot Basic Publishing Credentials Policies",
+                                    "description": "This module deploys a Web Site Slot Basic Publishing Credentials Policy."
+                                  },
+                                  "parameters": {
+                                    "name": {
+                                      "type": "string",
+                                      "allowedValues": [
+                                        "scm",
+                                        "ftp"
+                                      ],
+                                      "metadata": {
+                                        "description": "Required. The name of the resource."
+                                      }
+                                    },
+                                    "allow": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Set to true to enable or false to disable a publishing method."
+                                      }
+                                    },
+                                    "appName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent web site. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "slotName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent web site slot. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all Resources."
+                                      }
+                                    }
+                                  },
+                                  "resources": [
+                                    {
+                                      "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), parameters('name'))]",
+                                      "location": "[parameters('location')]",
+                                      "properties": {
+                                        "allow": "[parameters('allow')]"
+                                      }
+                                    }
+                                  ],
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the basic publishing credential policy."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the basic publishing credential policy."
+                                      },
+                                      "value": "[resourceId('Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies', parameters('appName'), parameters('slotName'), parameters('name'))]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the basic publishing credential policy was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference(resourceId('Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies', parameters('appName'), parameters('slotName'), parameters('name')), '2024-04-01', 'full').location]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_hybridConnectionRelays": {
+                              "copy": {
+                                "name": "slot_hybridConnectionRelays",
+                                "count": "[length(coalesce(parameters('hybridConnectionRelays'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-Slot-HybridConnectionRelay-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "hybridConnectionResourceId": {
+                                    "value": "[coalesce(parameters('hybridConnectionRelays'), createArray())[copyIndex()].resourceId]"
+                                  },
+                                  "appName": {
+                                    "value": "[parameters('appName')]"
+                                  },
+                                  "slotName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "sendKeyName": {
+                                    "value": "[tryGet(coalesce(parameters('hybridConnectionRelays'), createArray())[copyIndex()], 'sendKeyName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "16445776675656358479"
+                                    },
+                                    "name": "Web/Function Apps Slot Hybrid Connection Relay",
+                                    "description": "This module deploys a Site Slot Hybrid Connection Namespace Relay."
+                                  },
+                                  "parameters": {
+                                    "hybridConnectionResourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The resource ID of the relay namespace hybrid connection."
+                                      }
+                                    },
+                                    "slotName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the site slot. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "appName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent web site. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "sendKeyName": {
+                                      "type": "string",
+                                      "defaultValue": "defaultSender",
+                                      "metadata": {
+                                        "description": "Optional. Name of the authorization rule send key to use."
+                                      }
+                                    }
+                                  },
+                                  "resources": [
+                                    {
+                                      "type": "Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]",
+                                      "properties": {
+                                        "serviceBusNamespace": "[split(parameters('hybridConnectionResourceId'), '/')[8]]",
+                                        "serviceBusSuffix": "[split(substring(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces', split(parameters('hybridConnectionResourceId'), '/')[8]), '2021-11-01').serviceBusEndpoint, indexOf(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces', split(parameters('hybridConnectionResourceId'), '/')[8]), '2021-11-01').serviceBusEndpoint, '.servicebus')), ':')[0]]",
+                                        "relayName": "[split(parameters('hybridConnectionResourceId'), '/')[10]]",
+                                        "relayArmUri": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]",
+                                        "hostname": "[split(json(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '2021-11-01').userMetadata)[0].value, ':')[0]]",
+                                        "port": "[int(split(json(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '2021-11-01').userMetadata)[0].value, ':')[1])]",
+                                        "sendKeyName": "[parameters('sendKeyName')]",
+                                        "sendKeyValue": "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10], parameters('sendKeyName')), '2021-11-01').primaryKey]"
+                                      }
+                                    }
+                                  ],
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the hybrid connection relay.."
+                                      },
+                                      "value": "[format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the hybrid connection relay."
+                                      },
+                                      "value": "[resourceId('Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays', split(format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[0], split(format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[1], split(format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[2], split(format('{0}/{1}/{2}/{3}', parameters('appName'), parameters('slotName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[3])]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the resource was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            },
+                            "slot_extensionMSdeploy": {
+                              "condition": "[not(empty(parameters('msDeployConfiguration')))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-Site-Extension-MSDeploy', uniqueString(deployment().name, parameters('location')))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "appName": {
+                                    "value": "[parameters('appName')]"
+                                  },
+                                  "msDeployConfiguration": {
+                                    "value": "[coalesce(parameters('msDeployConfiguration'), createObject())]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "14895622660217616811"
+                                    },
+                                    "name": "Site Deployment Extension ",
+                                    "description": "This module deploys a Site extension for MSDeploy."
+                                  },
+                                  "parameters": {
+                                    "appName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The name of the parent site resource."
+                                      }
+                                    },
+                                    "msDeployConfiguration": {
+                                      "type": "object",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Sets the MSDeployment Properties."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "app": {
+                                      "existing": true,
+                                      "type": "Microsoft.Web/sites",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[parameters('appName')]"
+                                    },
+                                    "msdeploy": {
+                                      "type": "Microsoft.Web/sites/extensions",
+                                      "apiVersion": "2024-04-01",
+                                      "name": "[format('{0}/{1}', parameters('appName'), 'MSDeploy')]",
+                                      "kind": "MSDeploy",
+                                      "properties": "[parameters('msDeployConfiguration')]"
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the MSDeploy Package."
+                                      },
+                                      "value": "MSDeploy"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the Site Extension."
+                                      },
+                                      "value": "[resourceId('Microsoft.Web/sites/extensions', parameters('appName'), 'MSDeploy')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the site config was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "slot_privateEndpoints": {
+                              "copy": {
+                                "name": "slot_privateEndpoints",
+                                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-slot-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'subnetResourceId')), '/')[2]]",
+                              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'subnetResourceId')), '/')[4]]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('appName')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), format('sites-{0}', parameters('name'))), copyIndex()))]"
+                                  },
+                                  "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('appName')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), format('sites-{0}', parameters('name'))), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.Web/sites', parameters('appName')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), format('sites-{0}', parameters('name')))))))), createObject('value', null()))]",
+                                  "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('appName')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), format('sites-{0}', parameters('name'))), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.Web/sites', parameters('appName')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), format('sites-{0}', parameters('name')))), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                                  "subnetResourceId": {
+                                    "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                                  },
+                                  "location": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                                  },
+                                  "lock": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                                  },
+                                  "privateDnsZoneGroup": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                                  },
+                                  "roleAssignments": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                                  },
+                                  "tags": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                                  },
+                                  "customDnsConfigs": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                                  },
+                                  "ipConfigurations": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                                  },
+                                  "applicationSecurityGroupResourceIds": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                                  },
+                                  "customNetworkInterfaceName": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.29.47.4906",
+                                      "templateHash": "1277254088602407590"
+                                    },
+                                    "name": "Private Endpoints",
+                                    "description": "This module deploys a Private Endpoint.",
+                                    "owner": "Azure/module-maintainers"
+                                  },
+                                  "definitions": {
+                                    "privateDnsZoneGroupType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the Private DNS Zone Group."
+                                          }
+                                        },
+                                        "privateDnsZoneGroupConfigs": {
+                                          "type": "array",
+                                          "items": {
+                                            "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                          },
+                                          "metadata": {
+                                            "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "roleAssignmentType": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                            }
+                                          },
+                                          "roleDefinitionIdOrName": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                            }
+                                          },
+                                          "principalId": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                            }
+                                          },
+                                          "principalType": {
+                                            "type": "string",
+                                            "allowedValues": [
+                                              "Device",
+                                              "ForeignGroup",
+                                              "Group",
+                                              "ServicePrincipal",
+                                              "User"
+                                            ],
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. The principal type of the assigned principal ID."
+                                            }
+                                          },
+                                          "description": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. The description of the role assignment."
+                                            }
+                                          },
+                                          "condition": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                            }
+                                          },
+                                          "conditionVersion": {
+                                            "type": "string",
+                                            "allowedValues": [
+                                              "2.0"
+                                            ],
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. Version of the condition."
+                                            }
+                                          },
+                                          "delegatedManagedIdentityResourceId": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "metadata": {
+                                              "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "lockType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Specify the name of lock."
+                                          }
+                                        },
+                                        "kind": {
+                                          "type": "string",
+                                          "allowedValues": [
+                                            "CanNotDelete",
+                                            "None",
+                                            "ReadOnly"
+                                          ],
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Specify the type of lock."
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "ipConfigurationsType": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. The name of the resource that is unique within a resource group."
+                                            }
+                                          },
+                                          "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                              "groupId": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                                }
+                                              },
+                                              "memberName": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                                }
+                                              },
+                                              "privateIPAddress": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                                                }
+                                              }
+                                            },
+                                            "metadata": {
+                                              "description": "Required. Properties of private endpoint IP configurations."
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "manualPrivateLinkServiceConnectionsType": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. The name of the private link service connection."
+                                            }
+                                          },
+                                          "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                              "groupIds": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "metadata": {
+                                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                                                }
+                                              },
+                                              "privateLinkServiceId": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Required. The resource id of private link service."
+                                                }
+                                              },
+                                              "requestMessage": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                                                }
+                                              }
+                                            },
+                                            "metadata": {
+                                              "description": "Required. Properties of private link service connection."
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "privateLinkServiceConnectionsType": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. The name of the private link service connection."
+                                            }
+                                          },
+                                          "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                              "groupIds": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "metadata": {
+                                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                                                }
+                                              },
+                                              "privateLinkServiceId": {
+                                                "type": "string",
+                                                "metadata": {
+                                                  "description": "Required. The resource id of private link service."
+                                                }
+                                              },
+                                              "requestMessage": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "metadata": {
+                                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                                                }
+                                              }
+                                            },
+                                            "metadata": {
+                                              "description": "Required. Properties of private link service connection."
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "customDnsConfigType": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "fqdn": {
+                                            "type": "string",
+                                            "metadata": {
+                                              "description": "Required. Fqdn that resolves to private endpoint IP address."
+                                            }
+                                          },
+                                          "ipAddresses": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "metadata": {
+                                              "description": "Required. A list of private IP addresses of the private endpoint."
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "nullable": true
+                                    },
+                                    "privateDnsZoneGroupConfigType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the private DNS zone group config."
+                                          }
+                                        },
+                                        "privateDnsZoneResourceId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The resource id of the private DNS zone."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "private-dns-zone-group/main.bicep"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Name of the private endpoint resource to create."
+                                      }
+                                    },
+                                    "subnetResourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                                      }
+                                    },
+                                    "applicationSecurityGroupResourceIds": {
+                                      "type": "array",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                                      }
+                                    },
+                                    "customNetworkInterfaceName": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                                      }
+                                    },
+                                    "ipConfigurations": {
+                                      "$ref": "#/definitions/ipConfigurationsType",
+                                      "metadata": {
+                                        "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                                      }
+                                    },
+                                    "privateDnsZoneGroup": {
+                                      "$ref": "#/definitions/privateDnsZoneGroupType",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all Resources."
+                                      }
+                                    },
+                                    "lock": {
+                                      "$ref": "#/definitions/lockType",
+                                      "metadata": {
+                                        "description": "Optional. The lock settings of the service."
+                                      }
+                                    },
+                                    "roleAssignments": {
+                                      "$ref": "#/definitions/roleAssignmentType",
+                                      "metadata": {
+                                        "description": "Optional. Array of role assignments to create."
+                                      }
+                                    },
+                                    "tags": {
+                                      "type": "object",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                                      }
+                                    },
+                                    "customDnsConfigs": {
+                                      "$ref": "#/definitions/customDnsConfigType",
+                                      "metadata": {
+                                        "description": "Optional. Custom DNS configurations."
+                                      }
+                                    },
+                                    "manualPrivateLinkServiceConnections": {
+                                      "$ref": "#/definitions/manualPrivateLinkServiceConnectionsType",
+                                      "metadata": {
+                                        "description": "Optional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource."
+                                      }
+                                    },
+                                    "privateLinkServiceConnections": {
+                                      "$ref": "#/definitions/privateLinkServiceConnectionsType",
+                                      "metadata": {
+                                        "description": "Optional. A grouping of information about the connection to the remote resource."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "copy": [
+                                      {
+                                        "name": "formattedRoleAssignments",
+                                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                                      }
+                                    ],
+                                    "builtInRoleNames": {
+                                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2024-03-01",
+                                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.7.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "privateEndpoint": {
+                                      "type": "Microsoft.Network/privateEndpoints",
+                                      "apiVersion": "2023-11-01",
+                                      "name": "[parameters('name')]",
+                                      "location": "[parameters('location')]",
+                                      "tags": "[parameters('tags')]",
+                                      "properties": {
+                                        "copy": [
+                                          {
+                                            "name": "applicationSecurityGroups",
+                                            "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                                            "input": {
+                                              "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                                            }
+                                          }
+                                        ],
+                                        "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                                        "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                                        "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                                        "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                                        "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                                        "subnet": {
+                                          "id": "[parameters('subnetResourceId')]"
+                                        }
+                                      }
+                                    },
+                                    "privateEndpoint_lock": {
+                                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                                      "type": "Microsoft.Authorization/locks",
+                                      "apiVersion": "2020-05-01",
+                                      "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                                      "properties": {
+                                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    },
+                                    "privateEndpoint_roleAssignments": {
+                                      "copy": {
+                                        "name": "privateEndpoint_roleAssignments",
+                                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                                      },
+                                      "type": "Microsoft.Authorization/roleAssignments",
+                                      "apiVersion": "2022-04-01",
+                                      "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                                      "properties": {
+                                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    },
+                                    "privateEndpoint_privateDnsZoneGroup": {
+                                      "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2022-09-01",
+                                      "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                                      "properties": {
+                                        "expressionEvaluationOptions": {
+                                          "scope": "inner"
+                                        },
+                                        "mode": "Incremental",
+                                        "parameters": {
+                                          "name": {
+                                            "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                                          },
+                                          "privateEndpointName": {
+                                            "value": "[parameters('name')]"
+                                          },
+                                          "privateDnsZoneConfigs": {
+                                            "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                                          }
+                                        },
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "languageVersion": "2.0",
+                                          "contentVersion": "1.0.0.0",
+                                          "metadata": {
+                                            "_generator": {
+                                              "name": "bicep",
+                                              "version": "0.29.47.4906",
+                                              "templateHash": "5805178546717255803"
+                                            },
+                                            "name": "Private Endpoint Private DNS Zone Groups",
+                                            "description": "This module deploys a Private Endpoint Private DNS Zone Group.",
+                                            "owner": "Azure/module-maintainers"
+                                          },
+                                          "definitions": {
+                                            "privateDnsZoneGroupConfigType": {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "nullable": true,
+                                                  "metadata": {
+                                                    "description": "Optional. The name of the private DNS zone group config."
+                                                  }
+                                                },
+                                                "privateDnsZoneResourceId": {
+                                                  "type": "string",
+                                                  "metadata": {
+                                                    "description": "Required. The resource id of the private DNS zone."
+                                                  }
+                                                }
+                                              },
+                                              "metadata": {
+                                                "__bicep_export!": true
+                                              }
+                                            }
+                                          },
+                                          "parameters": {
+                                            "privateEndpointName": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                                              }
+                                            },
+                                            "privateDnsZoneConfigs": {
+                                              "type": "array",
+                                              "items": {
+                                                "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                              },
+                                              "minLength": 1,
+                                              "maxLength": 5,
+                                              "metadata": {
+                                                "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                                              }
+                                            },
+                                            "name": {
+                                              "type": "string",
+                                              "defaultValue": "default",
+                                              "metadata": {
+                                                "description": "Optional. The name of the private DNS zone group."
+                                              }
+                                            }
+                                          },
+                                          "variables": {
+                                            "copy": [
+                                              {
+                                                "name": "privateDnsZoneConfigsVar",
+                                                "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                                "input": {
+                                                  "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId, '/')))]",
+                                                  "properties": {
+                                                    "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId]"
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "resources": {
+                                            "privateEndpoint": {
+                                              "existing": true,
+                                              "type": "Microsoft.Network/privateEndpoints",
+                                              "apiVersion": "2023-11-01",
+                                              "name": "[parameters('privateEndpointName')]"
+                                            },
+                                            "privateDnsZoneGroup": {
+                                              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                              "apiVersion": "2023-11-01",
+                                              "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                                              "properties": {
+                                                "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
+                                              },
+                                              "dependsOn": [
+                                                "privateEndpoint"
+                                              ]
+                                            }
+                                          },
+                                          "outputs": {
+                                            "name": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The name of the private endpoint DNS zone group."
+                                              },
+                                              "value": "[parameters('name')]"
+                                            },
+                                            "resourceId": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The resource ID of the private endpoint DNS zone group."
+                                              },
+                                              "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                                            },
+                                            "resourceGroupName": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The resource group the private endpoint DNS zone group was deployed into."
+                                              },
+                                              "value": "[resourceGroup().name]"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    }
+                                  },
+                                  "outputs": {
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the private endpoint was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the private endpoint."
+                                      },
+                                      "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the private endpoint."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
+                                    },
+                                    "customDnsConfig": {
+                                      "$ref": "#/definitions/customDnsConfigType",
+                                      "metadata": {
+                                        "description": "The custom DNS configurations of the private endpoint."
+                                      },
+                                      "value": "[reference('privateEndpoint').customDnsConfigs]"
+                                    },
+                                    "networkInterfaceIds": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "description": "The IDs of the network interfaces associated with the private endpoint."
+                                      },
+                                      "value": "[reference('privateEndpoint').networkInterfaces]"
+                                    },
+                                    "groupId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The group Id for the private endpoint Group."
+                                      },
+                                      "value": "[if(and(not(empty(reference('privateEndpoint').manualPrivateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds', 0), ''), if(and(not(empty(reference('privateEndpoint').privateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds', 0), ''), ''))]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "slot"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the slot."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the slot."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/slots', parameters('appName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the slot was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "systemAssignedMIPrincipalId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The principal ID of the system assigned identity."
+                              },
+                              "value": "[tryGet(tryGet(reference('slot', '2024-04-01', 'full'), 'identity'), 'principalId')]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('slot', '2024-04-01', 'full').location]"
+                            },
+                            "privateEndpoints": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The private endpoints of the slot."
+                              },
+                              "copy": {
+                                "count": "[length(if(not(empty(parameters('privateEndpoints'))), array(parameters('privateEndpoints')), createArray()))]",
+                                "input": {
+                                  "name": "[reference(format('slot_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                                  "resourceId": "[reference(format('slot_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                                  "groupId": "[reference(format('slot_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
+                                  "customDnsConfig": "[reference(format('slot_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
+                                  "networkInterfaceIds": "[reference(format('slot_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceIds.value]"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_basicPublishingCredentialsPolicies": {
+                      "copy": {
+                        "name": "app_basicPublishingCredentialsPolicies",
+                        "count": "[length(coalesce(parameters('basicPublishingCredentialsPolicies'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Site-Publish-Cred-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "webAppName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "name": {
+                            "value": "[coalesce(parameters('basicPublishingCredentialsPolicies'), createArray())[copyIndex()].name]"
+                          },
+                          "allow": {
+                            "value": "[tryGet(coalesce(parameters('basicPublishingCredentialsPolicies'), createArray())[copyIndex()], 'allow')]"
+                          },
+                          "location": {
+                            "value": "[parameters('location')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "7001118912896436334"
+                            },
+                            "name": "Web Site Basic Publishing Credentials Policies",
+                            "description": "This module deploys a Web Site Basic Publishing Credentials Policy."
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "allowedValues": [
+                                "scm",
+                                "ftp"
+                              ],
+                              "metadata": {
+                                "description": "Required. The name of the resource."
+                              }
+                            },
+                            "allow": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Set to true to enable or false to disable a publishing method."
+                              }
+                            },
+                            "webAppName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent web site. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all Resources."
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}', parameters('webAppName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "properties": {
+                                "allow": "[parameters('allow')]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the basic publishing credential policy."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the basic publishing credential policy."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/basicPublishingCredentialsPolicies', parameters('webAppName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the basic publishing credential policy was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference(resourceId('Microsoft.Web/sites/basicPublishingCredentialsPolicies', parameters('webAppName'), parameters('name')), '2024-04-01', 'full').location]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_hybridConnectionRelays": {
+                      "copy": {
+                        "name": "app_hybridConnectionRelays",
+                        "count": "[length(coalesce(parameters('hybridConnectionRelays'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-HybridConnectionRelay-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "hybridConnectionResourceId": {
+                            "value": "[coalesce(parameters('hybridConnectionRelays'), createArray())[copyIndex()].resourceId]"
+                          },
+                          "appName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "sendKeyName": {
+                            "value": "[tryGet(coalesce(parameters('hybridConnectionRelays'), createArray())[copyIndex()], 'sendKeyName')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "13214417392638890300"
+                            },
+                            "name": "Web/Function Apps Hybrid Connection Relay",
+                            "description": "This module deploys a Site Hybrid Connection Namespace Relay."
+                          },
+                          "parameters": {
+                            "hybridConnectionResourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The resource ID of the relay namespace hybrid connection."
+                              }
+                            },
+                            "appName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent web site. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "sendKeyName": {
+                              "type": "string",
+                              "defaultValue": "defaultSender",
+                              "metadata": {
+                                "description": "Optional. Name of the authorization rule send key to use."
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Web/sites/hybridConnectionNamespaces/relays",
+                              "apiVersion": "2024-04-01",
+                              "name": "[format('{0}/{1}/{2}', parameters('appName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]",
+                              "properties": {
+                                "serviceBusNamespace": "[split(parameters('hybridConnectionResourceId'), '/')[8]]",
+                                "serviceBusSuffix": "[split(substring(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces', split(parameters('hybridConnectionResourceId'), '/')[8]), '2021-11-01').serviceBusEndpoint, indexOf(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces', split(parameters('hybridConnectionResourceId'), '/')[8]), '2021-11-01').serviceBusEndpoint, '.servicebus')), ':')[0]]",
+                                "relayName": "[split(parameters('hybridConnectionResourceId'), '/')[10]]",
+                                "relayArmUri": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]",
+                                "hostname": "[split(json(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '2021-11-01').userMetadata)[0].value, ':')[0]]",
+                                "port": "[int(split(json(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '2021-11-01').userMetadata)[0].value, ':')[1])]",
+                                "sendKeyName": "[parameters('sendKeyName')]",
+                                "sendKeyValue": "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('hybridConnectionResourceId'), '/')[2], split(parameters('hybridConnectionResourceId'), '/')[4]), 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules', split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10], parameters('sendKeyName')), '2021-11-01').primaryKey]"
+                              }
+                            }
+                          ],
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the hybrid connection relay.."
+                              },
+                              "value": "[format('{0}/{1}/{2}', parameters('appName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10])]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the hybrid connection relay."
+                              },
+                              "value": "[resourceId('Microsoft.Web/sites/hybridConnectionNamespaces/relays', split(format('{0}/{1}/{2}', parameters('appName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[0], split(format('{0}/{1}/{2}', parameters('appName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[1], split(format('{0}/{1}/{2}', parameters('appName'), split(parameters('hybridConnectionResourceId'), '/')[8], split(parameters('hybridConnectionResourceId'), '/')[10]), '/')[2])]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the resource was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    },
+                    "app_privateEndpoints": {
+                      "copy": {
+                        "name": "app_privateEndpoints",
+                        "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-app-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'subnetResourceId')), '/')[2]]",
+                      "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'subnetResourceId')), '/')[4]]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'sites'), copyIndex()))]"
+                          },
+                          "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'sites'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.Web/sites', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'sites')))))), createObject('value', null()))]",
+                          "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.Web/sites', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'sites'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.Web/sites', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'sites')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                          "subnetResourceId": {
+                            "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                          },
+                          "lock": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                          },
+                          "privateDnsZoneGroup": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                          },
+                          "roleAssignments": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "customDnsConfigs": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                          },
+                          "ipConfigurations": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                          },
+                          "applicationSecurityGroupResourceIds": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                          },
+                          "customNetworkInterfaceName": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.29.47.4906",
+                              "templateHash": "1277254088602407590"
+                            },
+                            "name": "Private Endpoints",
+                            "description": "This module deploys a Private Endpoint.",
+                            "owner": "Azure/module-maintainers"
+                          },
+                          "definitions": {
+                            "privateDnsZoneGroupType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private DNS Zone Group."
+                                  }
+                                },
+                                "privateDnsZoneGroupConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                                  }
+                                }
+                              }
+                            },
+                            "roleAssignmentType": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                    }
+                                  },
+                                  "roleDefinitionIdOrName": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                    }
+                                  },
+                                  "principalId": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                    }
+                                  },
+                                  "principalType": {
+                                    "type": "string",
+                                    "allowedValues": [
+                                      "Device",
+                                      "ForeignGroup",
+                                      "Group",
+                                      "ServicePrincipal",
+                                      "User"
+                                    ],
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. The principal type of the assigned principal ID."
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. The description of the role assignment."
+                                    }
+                                  },
+                                  "condition": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                    }
+                                  },
+                                  "conditionVersion": {
+                                    "type": "string",
+                                    "allowedValues": [
+                                      "2.0"
+                                    ],
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. Version of the condition."
+                                    }
+                                  },
+                                  "delegatedManagedIdentityResourceId": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "metadata": {
+                                      "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                    }
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "lockType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the name of lock."
+                                  }
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "CanNotDelete",
+                                    "None",
+                                    "ReadOnly"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "ipConfigurationsType": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. The name of the resource that is unique within a resource group."
+                                    }
+                                  },
+                                  "properties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "groupId": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                        }
+                                      },
+                                      "memberName": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                        }
+                                      },
+                                      "privateIPAddress": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                                        }
+                                      }
+                                    },
+                                    "metadata": {
+                                      "description": "Required. Properties of private endpoint IP configurations."
+                                    }
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "manualPrivateLinkServiceConnectionsType": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. The name of the private link service connection."
+                                    }
+                                  },
+                                  "properties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "groupIds": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "metadata": {
+                                          "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                                        }
+                                      },
+                                      "privateLinkServiceId": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The resource id of private link service."
+                                        }
+                                      },
+                                      "requestMessage": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                                        }
+                                      }
+                                    },
+                                    "metadata": {
+                                      "description": "Required. Properties of private link service connection."
+                                    }
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "privateLinkServiceConnectionsType": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. The name of the private link service connection."
+                                    }
+                                  },
+                                  "properties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "groupIds": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "metadata": {
+                                          "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                                        }
+                                      },
+                                      "privateLinkServiceId": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The resource id of private link service."
+                                        }
+                                      },
+                                      "requestMessage": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                                        }
+                                      }
+                                    },
+                                    "metadata": {
+                                      "description": "Required. Properties of private link service connection."
+                                    }
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "customDnsConfigType": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "fqdn": {
+                                    "type": "string",
+                                    "metadata": {
+                                      "description": "Required. Fqdn that resolves to private endpoint IP address."
+                                    }
+                                  },
+                                  "ipAddresses": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "metadata": {
+                                      "description": "Required. A list of private IP addresses of the private endpoint."
+                                    }
+                                  }
+                                }
+                              },
+                              "nullable": true
+                            },
+                            "privateDnsZoneGroupConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private DNS zone group config."
+                                  }
+                                },
+                                "privateDnsZoneResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource id of the private DNS zone."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "private-dns-zone-group/main.bicep"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Name of the private endpoint resource to create."
+                              }
+                            },
+                            "subnetResourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                              }
+                            },
+                            "applicationSecurityGroupResourceIds": {
+                              "type": "array",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                              }
+                            },
+                            "customNetworkInterfaceName": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                              }
+                            },
+                            "ipConfigurations": {
+                              "$ref": "#/definitions/ipConfigurationsType",
+                              "metadata": {
+                                "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                              }
+                            },
+                            "privateDnsZoneGroup": {
+                              "$ref": "#/definitions/privateDnsZoneGroupType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all Resources."
+                              }
+                            },
+                            "lock": {
+                              "$ref": "#/definitions/lockType",
+                              "metadata": {
+                                "description": "Optional. The lock settings of the service."
+                              }
+                            },
+                            "roleAssignments": {
+                              "$ref": "#/definitions/roleAssignmentType",
+                              "metadata": {
+                                "description": "Optional. Array of role assignments to create."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                              }
+                            },
+                            "customDnsConfigs": {
+                              "$ref": "#/definitions/customDnsConfigType",
+                              "metadata": {
+                                "description": "Optional. Custom DNS configurations."
+                              }
+                            },
+                            "manualPrivateLinkServiceConnections": {
+                              "$ref": "#/definitions/manualPrivateLinkServiceConnectionsType",
+                              "metadata": {
+                                "description": "Optional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource."
+                              }
+                            },
+                            "privateLinkServiceConnections": {
+                              "$ref": "#/definitions/privateLinkServiceConnectionsType",
+                              "metadata": {
+                                "description": "Optional. A grouping of information about the connection to the remote resource."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "formattedRoleAssignments",
+                                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                              }
+                            ],
+                            "builtInRoleNames": {
+                              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                              "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                              "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                              "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                              "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                              "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                              "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                              "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2024-03-01",
+                              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.7.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "privateEndpoint": {
+                              "type": "Microsoft.Network/privateEndpoints",
+                              "apiVersion": "2023-11-01",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "applicationSecurityGroups",
+                                    "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                                    "input": {
+                                      "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                                    }
+                                  }
+                                ],
+                                "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                                "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                                "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                                "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                                "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                                "subnet": {
+                                  "id": "[parameters('subnetResourceId')]"
+                                }
+                              }
+                            },
+                            "privateEndpoint_lock": {
+                              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                              "type": "Microsoft.Authorization/locks",
+                              "apiVersion": "2020-05-01",
+                              "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                              "properties": {
+                                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_roleAssignments": {
+                              "copy": {
+                                "name": "privateEndpoint_roleAssignments",
+                                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                              },
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                              "properties": {
+                                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_privateDnsZoneGroup": {
+                              "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                                  },
+                                  "privateEndpointName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "privateDnsZoneConfigs": {
+                                    "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.29.47.4906",
+                                      "templateHash": "5805178546717255803"
+                                    },
+                                    "name": "Private Endpoint Private DNS Zone Groups",
+                                    "description": "This module deploys a Private Endpoint Private DNS Zone Group.",
+                                    "owner": "Azure/module-maintainers"
+                                  },
+                                  "definitions": {
+                                    "privateDnsZoneGroupConfigType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the private DNS zone group config."
+                                          }
+                                        },
+                                        "privateDnsZoneResourceId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The resource id of the private DNS zone."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_export!": true
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "privateEndpointName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "privateDnsZoneConfigs": {
+                                      "type": "array",
+                                      "items": {
+                                        "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                      },
+                                      "minLength": 1,
+                                      "maxLength": 5,
+                                      "metadata": {
+                                        "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "default",
+                                      "metadata": {
+                                        "description": "Optional. The name of the private DNS zone group."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "copy": [
+                                      {
+                                        "name": "privateDnsZoneConfigsVar",
+                                        "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                        "input": {
+                                          "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId, '/')))]",
+                                          "properties": {
+                                            "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId]"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "resources": {
+                                    "privateEndpoint": {
+                                      "existing": true,
+                                      "type": "Microsoft.Network/privateEndpoints",
+                                      "apiVersion": "2023-11-01",
+                                      "name": "[parameters('privateEndpointName')]"
+                                    },
+                                    "privateDnsZoneGroup": {
+                                      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                      "apiVersion": "2023-11-01",
+                                      "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                                      "properties": {
+                                        "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the private endpoint DNS zone group was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the private endpoint was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the private endpoint."
+                              },
+                              "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the private endpoint."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
+                            },
+                            "customDnsConfig": {
+                              "$ref": "#/definitions/customDnsConfigType",
+                              "metadata": {
+                                "description": "The custom DNS configurations of the private endpoint."
+                              },
+                              "value": "[reference('privateEndpoint').customDnsConfigs]"
+                            },
+                            "networkInterfaceIds": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The IDs of the network interfaces associated with the private endpoint."
+                              },
+                              "value": "[reference('privateEndpoint').networkInterfaces]"
+                            },
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The group Id for the private endpoint Group."
+                              },
+                              "value": "[if(and(not(empty(reference('privateEndpoint').manualPrivateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds', 0), ''), if(and(not(empty(reference('privateEndpoint').privateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds', 0), ''), ''))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "app"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the site."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the site."
+                      },
+                      "value": "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+                    },
+                    "slots": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The list of the slots."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('slots'), createArray()))]",
+                        "input": "[format('{0}-Slot-{1}', uniqueString(deployment().name, parameters('location')), coalesce(parameters('slots'), createArray())[copyIndex()].name)]"
+                      }
+                    },
+                    "slotResourceIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The list of the slot resource ids."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('slots'), createArray()))]",
+                        "input": "[reference(format('app_slots[{0}]', copyIndex())).outputs.resourceId.value]"
+                      }
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource group the site was deployed into."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('app', '2024-04-01', 'full'), 'identity'), 'principalId')]"
+                    },
+                    "slotSystemAssignedMIPrincipalIds": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity of slots."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('slots'), createArray()))]",
+                        "input": "[coalesce(reference(format('app_slots[{0}]', copyIndex())).outputs.systemAssignedMIPrincipalId.value, '')]"
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('app', '2024-04-01', 'full').location]"
+                    },
+                    "defaultHostname": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Default hostname of the app."
+                      },
+                      "value": "[reference('app').defaultHostName]"
+                    },
+                    "customDomainVerificationId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification."
+                      },
+                      "value": "[reference('app').customDomainVerificationId]"
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The private endpoints of the site."
+                      },
+                      "copy": {
+                        "count": "[length(if(not(empty(parameters('privateEndpoints'))), array(parameters('privateEndpoints')), createArray()))]",
+                        "input": {
+                          "name": "[reference(format('app_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                          "resourceId": "[reference(format('app_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                          "groupId": "[reference(format('app_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
+                          "customDnsConfig": "[reference(format('app_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
+                          "networkInterfaceIds": "[reference(format('app_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceIds.value]"
+                        }
+                      }
+                    },
+                    "slotPrivateEndpoints": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The private endpoints of the slots."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('slots'), createArray()))]",
+                        "input": "[reference(format('app_slots[{0}]', copyIndex())).outputs.privateEndpoints.value]"
+                      }
+                    },
+                    "outboundIpAddresses": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The outbound IP addresses of the app."
+                      },
+                      "value": "[reference('app').outboundIpAddresses]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]",
+                "[resourceId('Microsoft.Resources/deployments', format('{0}-asp', uniqueString(deployment().name, parameters('location'))))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "appServicePlanId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the App Service Plan."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-asp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.resourceId.value]"
+            },
+            "appServicePlanName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the App Service Plan."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-asp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.name.value]"
+            },
+            "webAppId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Web App."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.resourceId.value]"
+            },
+            "webAppName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Web App."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.name.value]"
+            },
+            "webAppDefaultHostname": {
+              "type": "string",
+              "metadata": {
+                "description": "The default hostname of the Web App."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.defaultHostname.value]"
+            },
+            "webAppUrl": {
+              "type": "string",
+              "metadata": {
+                "description": "The URL of the Web App."
+              },
+              "value": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', format('{0}-webapp', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.defaultHostname.value)]"
+            },
+            "appInsightsId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of Application Insights."
+              },
+              "value": "[if(parameters('enableApplicationInsights'), resourceId('Microsoft.Insights/components', variables('appInsightsName')), '')]"
+            },
+            "appInsightsInstrumentationKey": {
+              "type": "string",
+              "metadata": {
+                "description": "The instrumentation key of Application Insights."
+              },
+              "value": "[if(parameters('enableApplicationInsights'), reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').InstrumentationKey, '')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-law', uniqueString(deployment().name, parameters('location'))))]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-chaos', uniqueString(deployment().name, parameters('location')))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "namePrefix": {
+            "value": "[parameters('namePrefix')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "appServiceResourceId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.webAppId.value]"
+          },
+          "enableChaosStudio": {
+            "value": "[parameters('enableChaosStudio')]"
+          },
+          "experimentDuration": {
+            "value": "[parameters('chaosExperimentDuration')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.39.26.7824",
+              "templateHash": "14918518963125810776"
+            }
+          },
+          "parameters": {
+            "namePrefix": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name prefix for resources."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Location for the Chaos experiment."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags for all resources."
+              }
+            },
+            "appServiceResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The resource ID of the App Service to target."
+              }
+            },
+            "enableChaosStudio": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable the Chaos Studio target and experiment."
+              }
+            },
+            "experimentDuration": {
+              "type": "string",
+              "defaultValue": "PT10M",
+              "metadata": {
+                "description": "Optional. Duration of the chaos experiment (ISO 8601 format)."
+              }
+            }
+          },
+          "variables": {
+            "experimentName": "[format('chaos-exp-{0}', parameters('namePrefix'))]",
+            "webAppName": "[last(split(parameters('appServiceResourceId'), '/'))]"
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableChaosStudio')]",
+              "type": "Microsoft.Chaos/targets",
+              "apiVersion": "2024-01-01",
+              "scope": "[format('Microsoft.Web/sites/{0}', variables('webAppName'))]",
+              "name": "Microsoft-AppService",
+              "location": "[parameters('location')]",
+              "properties": {}
+            },
+            {
+              "condition": "[parameters('enableChaosStudio')]",
+              "type": "Microsoft.Chaos/targets/capabilities",
+              "apiVersion": "2024-01-01",
+              "scope": "[format('Microsoft.Web/sites/{0}', variables('webAppName'))]",
+              "name": "[format('{0}/{1}', 'Microsoft-AppService', 'Stop-1.0')]",
+              "dependsOn": [
+                "[extensionResourceId(resourceId('Microsoft.Web/sites', variables('webAppName')), 'Microsoft.Chaos/targets', 'Microsoft-AppService')]"
+              ]
+            },
+            {
+              "condition": "[parameters('enableChaosStudio')]",
+              "type": "Microsoft.Chaos/experiments",
+              "apiVersion": "2024-01-01",
+              "name": "[variables('experimentName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "selectors": [
+                  {
+                    "id": "Selector1",
+                    "type": "List",
+                    "targets": [
+                      {
+                        "id": "[extensionResourceId(resourceId('Microsoft.Web/sites', variables('webAppName')), 'Microsoft.Chaos/targets', 'Microsoft-AppService')]",
+                        "type": "ChaosTarget"
+                      }
+                    ]
+                  }
+                ],
+                "steps": [
+                  {
+                    "name": "Step1-StopAppService",
+                    "branches": [
+                      {
+                        "name": "Branch1",
+                        "actions": [
+                          {
+                            "name": "urn:csci:microsoft:appService:stop/1.0",
+                            "type": "continuous",
+                            "duration": "[parameters('experimentDuration')]",
+                            "parameters": [],
+                            "selectorId": "Selector1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[extensionResourceId(resourceId('Microsoft.Web/sites', variables('webAppName')), 'Microsoft.Chaos/targets', 'Microsoft-AppService')]"
+              ]
+            },
+            {
+              "condition": "[parameters('enableChaosStudio')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.Web/sites/{0}', variables('webAppName'))]",
+              "name": "[guid(resourceId('Microsoft.Web/sites', variables('webAppName')), resourceId('Microsoft.Chaos/experiments', variables('experimentName')), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]",
+                "principalId": "[reference(resourceId('Microsoft.Chaos/experiments', variables('experimentName')), '2024-01-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Chaos/experiments', variables('experimentName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "experimentId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Chaos Studio experiment."
+              },
+              "value": "[if(parameters('enableChaosStudio'), resourceId('Microsoft.Chaos/experiments', variables('experimentName')), '')]"
+            },
+            "experimentName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Chaos Studio experiment."
+              },
+              "value": "[if(parameters('enableChaosStudio'), variables('experimentName'), '')]"
+            },
+            "experimentPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "The principal ID of the Chaos experiment managed identity."
+              },
+              "value": "[if(parameters('enableChaosStudio'), reference(resourceId('Microsoft.Chaos/experiments', variables('experimentName')), '2024-01-01', 'full').identity.principalId, '')]"
+            },
+            "targetId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Chaos target."
+              },
+              "value": "[if(parameters('enableChaosStudio'), extensionResourceId(resourceId('Microsoft.Web/sites', variables('webAppName')), 'Microsoft.Chaos/targets', 'Microsoft-AppService'), '')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location'))))]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource group."
+      },
+      "value": "[parameters('resourceGroupName')]"
+    },
+    "resourceGroupId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the resource group."
+      },
+      "value": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+    },
+    "webAppName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Web App."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.webAppName.value]"
+    },
+    "webAppUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "The URL of the Web App."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.webAppUrl.value]"
+    },
+    "webAppResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the Web App."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.webAppId.value]"
+    },
+    "appServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Service Plan."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-appservice', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.appServicePlanName.value]"
+    },
+    "chaosExperimentId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the Chaos Studio experiment."
+      },
+      "value": "[if(parameters('enableChaosStudio'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-chaos', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.experimentId.value, '')]"
+    },
+    "chaosExperimentName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Chaos Studio experiment."
+      },
+      "value": "[if(parameters('enableChaosStudio'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-chaos', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.experimentName.value, '')]"
+    },
+    "logAnalyticsWorkspaceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the Log Analytics workspace."
+      },
+      "value": "[if(parameters('deployLogAnalytics'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-law', uniqueString(deployment().name, parameters('location')))), '2025-04-01').outputs.resourceId.value, '')]"
+    },
+    "sreAgentInstructions": {
+      "type": "string",
+      "metadata": {
+        "description": "Instructions for SRE Agent setup."
+      },
+      "value": "=== SRE Agent Setup Instructions ===\nSRE Agent is currently in Preview and must be set up via the Azure Portal.\n\n1. Navigate to the Azure Portal: https://portal.azure.com\n2. Search for \"Azure SRE Agent\" in the search bar\n3. Select \"+ Create\" to create a new agent\n4. Configure the agent:\n   - Subscription: Your subscription\n   - Resource Group: Create a new one (e.g., rg-sre-agent)\n   - Name: my-sre-agent\n   - Region: East US 2 (or available region)\n5. Select \"Select resource groups\" and choose the resource group containing your App Service\n6. Click \"Create\"\n\nAfter creation, you can:\n- Chat with your agent to monitor the App Service\n- Use the \"broken\" deployment slot to simulate failures\n- Let the agent diagnose and remediate issues\n\nFor more details, see: https://learn.microsoft.com/en-us/azure/sre-agent/troubleshoot-azure-app-service\n"
+    }
+  }
+}

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namePrefix": {
+      "value": "sreagent"
+    },
+    "location": {
+      "value": "swedencentral"
+    },
+    "resourceGroupName": {
+      "value": "rg-sre-agent-demo"
+    },
+    "tags": {
+      "value": {
+        "Environment": "Demo",
+        "Project": "SRE-Agent",
+        "Owner": "Platform-Team"
+      }
+    },
+    "appServiceSkuName": {
+      "value": "S1"
+    },
+    "runtimeStack": {
+      "value": "DOTNETCORE|9.0"
+    },
+    "externalGitRepoUrl": {
+      "value": "https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial"
+    },
+    "externalGitBranch": {
+      "value": "main"
+    },
+    "enableApplicationInsights": {
+      "value": true
+    },
+    "enableChaosStudio": {
+      "value": true
+    },
+    "chaosExperimentDuration": {
+      "value": "PT10M"
+    },
+    "deployLogAnalytics": {
+      "value": true
+    }
+  }
+}

--- a/infra/modules/app-service.bicep
+++ b/infra/modules/app-service.bicep
@@ -1,0 +1,234 @@
+// App Service Module
+// Deploys an App Service Plan and Web App with deployment slot for SRE Agent monitoring
+
+@description('Required. Name prefix for resources.')
+param namePrefix string
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags for all resources.')
+param tags object = {}
+
+@description('Optional. The SKU name for the App Service Plan.')
+@allowed([
+  'F1'
+  'B1'
+  'B2'
+  'B3'
+  'S1'
+  'S2'
+  'S3'
+  'P1v3'
+  'P2v3'
+  'P3v3'
+])
+param skuName string = 'S1'
+
+@description('Optional. The runtime stack for the web app.')
+@allowed([
+  'DOTNETCORE|9.0'
+  'DOTNETCORE|8.0'
+  'NODE|20-lts'
+  'NODE|18-lts'
+  'PYTHON|3.12'
+  'PYTHON|3.11'
+])
+param runtimeStack string = 'DOTNETCORE|9.0'
+
+@description('Optional. External Git repository URL for deployment.')
+param externalGitRepoUrl string = 'https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial'
+
+@description('Optional. Branch of the external Git repository.')
+param externalGitBranch string = 'main'
+
+@description('Optional. Enable Application Insights.')
+param enableApplicationInsights bool = true
+
+@description('Optional. Log Analytics Workspace resource ID for diagnostics.')
+param logAnalyticsWorkspaceId string = ''
+
+// Variables
+var appServicePlanName = 'asp-${namePrefix}'
+var webAppName = 'app-${namePrefix}'
+var appInsightsName = 'appi-${namePrefix}'
+var isLinux = contains(runtimeStack, 'NODE') || contains(runtimeStack, 'PYTHON')
+
+// App Service Plan using AVM module
+module appServicePlan 'br/public:avm/res/web/serverfarm:0.4.1' = {
+  name: '${uniqueString(deployment().name, location)}-asp'
+  params: {
+    name: appServicePlanName
+    location: location
+    tags: tags
+    skuName: skuName
+    skuCapacity: 1
+    kind: isLinux ? 'linux' : 'app'
+    reserved: isLinux
+    diagnosticSettings: !empty(logAnalyticsWorkspaceId)
+      ? [
+          {
+            workspaceResourceId: logAnalyticsWorkspaceId
+            metricCategories: [
+              {
+                category: 'AllMetrics'
+              }
+            ]
+          }
+        ]
+      : []
+  }
+}
+
+// Application Insights
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = if (enableApplicationInsights) {
+  name: appInsightsName
+  location: location
+  tags: tags
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: !empty(logAnalyticsWorkspaceId) ? logAnalyticsWorkspaceId : null
+  }
+}
+
+// Web App using AVM module
+module webApp 'br/public:avm/res/web/site:0.13.3' = {
+  name: '${uniqueString(deployment().name, location)}-webapp'
+  params: {
+    name: webAppName
+    location: location
+    tags: tags
+    kind: isLinux ? 'app,linux' : 'app'
+    serverFarmResourceId: appServicePlan.outputs.resourceId
+    httpsOnly: true
+    publicNetworkAccess: 'Enabled'
+    siteConfig: {
+      linuxFxVersion: isLinux ? runtimeStack : null
+      netFrameworkVersion: !isLinux && contains(runtimeStack, 'DOTNETCORE') ? 'v9.0' : null
+      alwaysOn: skuName != 'F1' // Always On not supported on Free tier
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      http20Enabled: true
+    }
+    appInsightResourceId: enableApplicationInsights ? appInsights.id : null
+    // Enable managed identity on the main web app
+    managedIdentities: {
+      systemAssigned: true
+    }
+    // Deployment slots (only supported on Standard tier and above)
+    slots: contains(['F1', 'B1', 'B2', 'B3'], skuName)
+      ? []
+      : [
+          {
+            name: 'broken'
+            managedIdentities: {
+              systemAssigned: true
+            }
+            siteConfig: {
+              linuxFxVersion: isLinux ? runtimeStack : null
+              netFrameworkVersion: !isLinux && contains(runtimeStack, 'DOTNETCORE') ? 'v9.0' : null
+              alwaysOn: true
+              ftpsState: 'Disabled'
+              minTlsVersion: '1.2'
+              http20Enabled: true
+            }
+          }
+        ]
+    basicPublishingCredentialsPolicies: [
+      {
+        name: 'ftp'
+        allow: false
+      }
+      {
+        name: 'scm'
+        allow: true // Required for External Git deployment
+      }
+    ]
+    diagnosticSettings: !empty(logAnalyticsWorkspaceId)
+      ? [
+          {
+            workspaceResourceId: logAnalyticsWorkspaceId
+            logCategoriesAndGroups: [
+              {
+                categoryGroup: 'allLogs'
+              }
+            ]
+            metricCategories: [
+              {
+                category: 'AllMetrics'
+              }
+            ]
+          }
+        ]
+      : []
+  }
+}
+
+// Configure External Git deployment for main slot
+resource webAppSourceControl 'Microsoft.Web/sites/sourcecontrols@2023-12-01' = {
+  name: '${webAppName}/web'
+  dependsOn: [
+    webApp
+  ]
+  properties: {
+    repoUrl: externalGitRepoUrl
+    branch: externalGitBranch
+    isManualIntegration: true
+  }
+}
+
+// Variable to check if slots are supported (Standard tier and above)
+var slotsSupported = !contains(['F1', 'B1', 'B2', 'B3'], skuName)
+
+// Configure External Git deployment for broken slot (only when slots are supported)
+resource slotSourceControl 'Microsoft.Web/sites/slots/sourcecontrols@2023-12-01' = if (slotsSupported) {
+  name: '${webAppName}/broken/web'
+  dependsOn: [
+    webApp
+  ]
+  properties: {
+    repoUrl: externalGitRepoUrl
+    branch: externalGitBranch
+    isManualIntegration: true
+  }
+}
+
+// Configure app setting for broken slot to enable error injection (only when slots are supported)
+resource brokenSlotAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = if (slotsSupported) {
+  name: '${webAppName}/broken/appsettings'
+  dependsOn: [
+    slotSourceControl
+  ]
+  properties: {
+    INJECT_ERROR: '1'
+    APPLICATIONINSIGHTS_CONNECTION_STRING: enableApplicationInsights ? appInsights!.properties.ConnectionString : ''
+  }
+}
+
+// Outputs
+@description('The resource ID of the App Service Plan.')
+output appServicePlanId string = appServicePlan.outputs.resourceId
+
+@description('The name of the App Service Plan.')
+output appServicePlanName string = appServicePlan.outputs.name
+
+@description('The resource ID of the Web App.')
+output webAppId string = webApp.outputs.resourceId
+
+@description('The name of the Web App.')
+output webAppName string = webApp.outputs.name
+
+@description('The default hostname of the Web App.')
+output webAppDefaultHostname string = webApp.outputs.defaultHostname
+
+@description('The URL of the Web App.')
+output webAppUrl string = 'https://${webApp.outputs.defaultHostname}'
+
+@description('The resource ID of Application Insights.')
+output appInsightsId string = enableApplicationInsights ? appInsights!.id : ''
+
+@description('The instrumentation key of Application Insights.')
+output appInsightsInstrumentationKey string = enableApplicationInsights
+  ? appInsights!.properties.InstrumentationKey
+  : ''

--- a/infra/modules/chaos-studio.bicep
+++ b/infra/modules/chaos-studio.bicep
@@ -1,0 +1,120 @@
+// Chaos Studio Module
+// Deploys Chaos Studio experiment with App Service targets and capabilities
+
+@description('Required. Name prefix for resources.')
+param namePrefix string
+
+@description('Required. Location for the Chaos experiment.')
+param location string
+
+@description('Optional. Tags for all resources.')
+param tags object = {}
+
+@description('Required. The resource ID of the App Service to target.')
+param appServiceResourceId string
+
+@description('Optional. Enable the Chaos Studio target and experiment.')
+param enableChaosStudio bool = true
+
+@description('Optional. Duration of the chaos experiment (ISO 8601 format).')
+param experimentDuration string = 'PT10M'
+
+// Variables
+var experimentName = 'chaos-exp-${namePrefix}'
+var webAppName = last(split(appServiceResourceId, '/'))
+
+// Reference the existing Web App
+resource webApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: webAppName
+}
+
+// Chaos Studio Target - Enable App Service as a target
+resource chaosTarget 'Microsoft.Chaos/targets@2024-01-01' = if (enableChaosStudio) {
+  name: 'Microsoft-AppService'
+  location: location
+  scope: webApp
+  properties: {}
+}
+
+// Chaos Studio Capability - Stop App Service
+resource stopCapability 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableChaosStudio) {
+  name: 'Stop-1.0'
+  parent: chaosTarget
+}
+
+// Chaos Studio Capability - Kill Process (if available for App Service)
+// Note: Not all capabilities are available for all resource types
+// For App Service, the main capability is Stop
+
+// Role Definition for Chaos Experiment (Website Contributor)
+resource websiteContributorRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: 'de139f84-1756-47ae-9be6-808fbbe84772' // Website Contributor role
+}
+
+// Chaos Studio Experiment
+resource chaosExperiment 'Microsoft.Chaos/experiments@2024-01-01' = if (enableChaosStudio) {
+  name: experimentName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    selectors: [
+      {
+        id: 'Selector1'
+        type: 'List'
+        targets: [
+          {
+            id: chaosTarget.id
+            type: 'ChaosTarget'
+          }
+        ]
+      }
+    ]
+    steps: [
+      {
+        name: 'Step1-StopAppService'
+        branches: [
+          {
+            name: 'Branch1'
+            actions: [
+              {
+                name: 'urn:csci:microsoft:appService:stop/1.0'
+                type: 'continuous'
+                duration: experimentDuration
+                parameters: []
+                selectorId: 'Selector1'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+// Role Assignment - Grant Chaos Experiment permission to stop App Service
+resource chaosRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableChaosStudio) {
+  name: guid(webApp.id, chaosExperiment!.id, websiteContributorRole.id)
+  scope: webApp
+  properties: {
+    roleDefinitionId: websiteContributorRole.id
+    principalId: chaosExperiment!.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Outputs
+@description('The resource ID of the Chaos Studio experiment.')
+output experimentId string = enableChaosStudio ? chaosExperiment!.id : ''
+
+@description('The name of the Chaos Studio experiment.')
+output experimentName string = enableChaosStudio ? chaosExperiment!.name : ''
+
+@description('The principal ID of the Chaos experiment managed identity.')
+output experimentPrincipalId string = enableChaosStudio ? chaosExperiment!.identity.principalId : ''
+
+@description('The resource ID of the Chaos target.')
+output targetId string = enableChaosStudio ? chaosTarget!.id : ''


### PR DESCRIPTION
- Introduced main.parameters.json for parameter management.
- Created app-service.bicep module to deploy App Service Plan and Web App with external Git integration and Application Insights.
- Added chaos-studio.bicep module to configure Chaos Studio experiments targeting the App Service.

closes #2 