### PR TITLE
feat(demo-app): add .NET 9 web application with error simulation and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Repo to consolidate Azure SRE Agent demos and resources
 
+## Sample Application
+
+This repository includes a .NET 9 web application (`src/SreAgentDemo`) that demonstrates Azure App Service deployment slots, error simulation, and integration with the Azure SRE (Site Reliability Engineering) Agent for AI-assisted troubleshooting.
+
+### How the Demo App Works
+
+- **Normal Mode**: The main page shows a counter and two buttons: **Increment** and **Reset Counter**
+- **Error Simulation**: When the `INJECT_ERROR` app setting is set to `1`, clicking "Increment" 6 times triggers an HTTP 500 error
+- **Deployment Slots**: The "broken" slot has error injection enabled by default for testing failures without affecting production
+
+### Running Locally
+
+```bash
+cd src/SreAgentDemo
+
+# Run with error injection disabled
+dotnet run
+
+# Run with error injection enabled
+INJECT_ERROR=1 dotnet run
+```
+
+The app will be available at `http://localhost:5121` or `https://localhost:7159`.
+
+### Application Files
+
+| File                                            | Description                         |
+| ----------------------------------------------- | ----------------------------------- |
+| `src/SreAgentDemo/Program.cs`                   | Main app logic and web server setup |
+| `src/SreAgentDemo/appsettings.json`             | App configuration (default)         |
+| `src/SreAgentDemo/appsettings.Development.json` | Development environment config      |
+| `src/SreAgentDemo/SreAgentDemo.csproj`          | Project file                        |
+
 ## Infrastructure Deployment
 
 This repository includes Bicep Infrastructure as Code (IaC) to deploy the complete SRE Agent demo environment, including:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -44,10 +44,13 @@ param appServiceSkuName string = 'S1'
 param runtimeStack string = 'DOTNETCORE|9.0'
 
 @description('Optional. External Git repository URL for deployment.')
-param externalGitRepoUrl string = 'https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial'
+param externalGitRepoUrl string = 'https://github.com/tannenbaum-gmbh/sre-agent'
 
 @description('Optional. Branch of the external Git repository.')
 param externalGitBranch string = 'main'
+
+@description('Optional. Path to the application source code within the repository.')
+param appSourcePath string = 'src/SreAgentDemo'
 
 @description('Optional. Enable Application Insights.')
 param enableApplicationInsights bool = true
@@ -102,6 +105,7 @@ module appService 'modules/app-service.bicep' = {
     runtimeStack: runtimeStack
     externalGitRepoUrl: externalGitRepoUrl
     externalGitBranch: externalGitBranch
+    appSourcePath: appSourcePath
     enableApplicationInsights: enableApplicationInsights
     logAnalyticsWorkspaceId: deployLogAnalytics ? logAnalytics!.outputs.resourceId : ''
   }

--- a/infra/modules/app-service.bicep
+++ b/infra/modules/app-service.bicep
@@ -37,10 +37,13 @@ param skuName string = 'S1'
 param runtimeStack string = 'DOTNETCORE|9.0'
 
 @description('Optional. External Git repository URL for deployment.')
-param externalGitRepoUrl string = 'https://github.com/Azure-Samples/app-service-dotnet-agent-tutorial'
+param externalGitRepoUrl string = 'https://github.com/tannenbaum-gmbh/sre-agent'
 
 @description('Optional. Branch of the external Git repository.')
 param externalGitBranch string = 'main'
+
+@description('Optional. Path to the application source code within the repository.')
+param appSourcePath string = 'src/SreAgentDemo'
 
 @description('Optional. Enable Application Insights.')
 param enableApplicationInsights bool = true
@@ -186,6 +189,7 @@ resource mainSlotAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
     webApp
   ]
   properties: {
+    PROJECT: appSourcePath
     APPLICATIONINSIGHTS_CONNECTION_STRING: enableApplicationInsights ? appInsights!.properties.ConnectionString : ''
     ApplicationInsightsAgent_EXTENSION_VERSION: '~3'
   }
@@ -214,6 +218,7 @@ resource brokenSlotAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = i
     slotSourceControl
   ]
   properties: {
+    PROJECT: appSourcePath
     INJECT_ERROR: '1'
     APPLICATIONINSIGHTS_CONNECTION_STRING: enableApplicationInsights ? appInsights!.properties.ConnectionString : ''
     ApplicationInsightsAgent_EXTENSION_VERSION: '~3'

--- a/src/SreAgentDemo/Program.cs
+++ b/src/SreAgentDemo/Program.cs
@@ -1,0 +1,123 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", async context =>
+{
+    context.Response.ContentType = "text/html; charset=utf-8";
+    bool injectError = Environment.GetEnvironmentVariable("INJECT_ERROR") == "1";
+    bool safeMode = context.Request.Query.ContainsKey("safe");
+    bool buttonPressed = context.Request.Query.ContainsKey("crash");
+
+    int pressCount = 0;
+    if (context.Request.Cookies.TryGetValue("crashCount", out var cookieVal))
+        int.TryParse(cookieVal, out pressCount);
+
+    if (safeMode)
+        pressCount = 0;
+
+    if (buttonPressed && !safeMode)
+        pressCount++;
+
+    context.Response.Cookies.Append("crashCount", pressCount.ToString(), new CookieOptions { Expires = DateTimeOffset.Now.AddHours(1) });
+
+    if (injectError && !safeMode && buttonPressed && pressCount > 5)
+        throw new Exception("Simulated error after 5 button clicks!");
+
+    string buttonColor = injectError ? "#22c55e" : "#22c55e";
+    string buttonHover = injectError ? "#15803d" : "#15803d";
+
+    await context.Response.WriteAsync($@"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>.NET Button Click Demo</title>
+    <style>
+        body {{
+            background: #f8fafc;
+            font-family: 'Segoe UI', Arial, sans-serif;
+            text-align: center;
+            margin: 0; padding: 0;
+        }}
+        .container {{
+            margin-top: 80px;
+            background: #fff;
+            border-radius: 18px;
+            box-shadow: 0 6px 24px rgba(0,0,0,0.08);
+            display: inline-block;
+            padding: 40px 36px 36px 36px;
+        }}
+        .number {{
+            font-size: 3.2em;
+            color: #2563eb;
+            margin-bottom: 18px;
+        }}
+        .note {{
+            margin-top: 12px;
+            color: #ad6800;
+            font-size: 1em;
+        }}
+        .warning {{
+            margin-top: 30px;
+            color: #b91c1c;
+            font-weight: bold;
+            font-size: 1.3em;
+        }}
+        button {{
+            margin-top: 30px;
+            background: {buttonColor};
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            font-size: 1.2em;
+            padding: 12px 28px;
+            cursor: pointer;
+            transition: background 0.2s;
+        }}
+        button:disabled {{
+            opacity: 0.5;
+            cursor: not-allowed;
+        }}
+        button:hover:enabled {{
+            background: {buttonHover};
+        }}
+        .safe-btn {{
+            margin-top: 16px;
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            font-size: 1em;
+            padding: 8px 22px;
+            cursor: pointer;
+        }}
+        .safe-btn:hover {{
+            background: #1e40af;
+        }}
+    </style>
+</head>
+<body>
+    <div class='container'>
+        <div class='number' id='counter'>{pressCount}</div>
+        <form method='GET' style='display:inline'>
+            <input type='hidden' name='crash' value='1' />
+            <button id='incrementBtn' type='submit'>Increment</button>
+        </form>
+        <form method='GET' style='display:inline'>
+            <input type='hidden' name='safe' value='1' />
+            <button class='safe-btn' type='submit'>Reset Counter</button>
+        </form>
+        {(injectError ? $"<div class='note'>Button clicked <b>{pressCount}</b> times (error on 6th click).</div>" : "")}
+        {(injectError ? "<div class='warning'>ERROR INJECTION ENABLED: Simulated error will occur after 5 clicks.<br/>This is for troubleshooting demos.<br/>To stop the HTTP 500s, append \"?=safe=1\" to the URL.</div>" : "")}
+        <div class='note'>Note: For the demo to work, set app setting <b>INJECT_ERROR=1</b> on the slot you want to simulate errors!</div>
+    </div>
+</body>
+</html>
+    ");
+});
+
+app.Run();

--- a/src/SreAgentDemo/Properties/launchSettings.json
+++ b/src/SreAgentDemo/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5121",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7159;http://localhost:5121",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/SreAgentDemo/SreAgentDemo.csproj
+++ b/src/SreAgentDemo/SreAgentDemo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/SreAgentDemo/appsettings.Development.json
+++ b/src/SreAgentDemo/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/SreAgentDemo/appsettings.json
+++ b/src/SreAgentDemo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This pull request introduces a new .NET 9 web application demo (`src/SreAgentDemo`) to the repository, designed to showcase Azure App Service deployment slots, error simulation, and integration with the Azure SRE Agent. It also updates the infrastructure Bicep templates to deploy this new sample app from the correct source path and repository. The README is updated with detailed instructions and explanations for running and using the demo.

**Application Addition**

* Added a new .NET 9 web application in `src/SreAgentDemo`, including the main logic (`Program.cs`), configuration files (`appsettings.json`, `appsettings.Development.json`, `launchSettings.json`), and project file (`SreAgentDemo.csproj`). The app demonstrates counter functionality, error injection via the `INJECT_ERROR` setting, and deployment slot behavior. [[1]](diffhunk://#diff-36c0b036c6d82e6e10f10d01ea5b9a2e9a99128fe9502f639255b143815b7174R1-R123) [[2]](diffhunk://#diff-e3dbdc51eb00fd477c64b0c1e4415fbd1b1b1442b47ab0a9c0966f5a402831e8R1-R23) [[3]](diffhunk://#diff-149fb4f4c7a2fbcc9e1c630b70fd4fbf9ac6e6a0283a8eb7e3d0fd981fe6a86eR1-R13) [[4]](diffhunk://#diff-30e1b79e3f3649d3af7b5108ade0cf555d5a86205873f6ef6449096023f8bce4R1-R8) [[5]](diffhunk://#diff-725b64d66e549519d2b7290df5f4861930e5c16640710c463a49cdf2ece954b4R1-R9)

**Documentation Updates**

* Enhanced the `README.md` with a new "Sample Application" section, describing the demo app's features, usage instructions, and file structure to help users understand and run the demo locally.

**Infrastructure Deployment Changes**

* Updated the Bicep templates (`infra/main.bicep`, `infra/modules/app-service.bicep`) to:
  - Point to the new GitHub repository and source path for the demo app.
  - Pass the application source path as a parameter and set it in the app settings for both main and broken slots, ensuring correct deployment and error simulation configuration. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L47-R54) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R108) [[3]](diffhunk://#diff-9f2f4688660b09cb845faa7f555cc6473b0495a083af7bbfa7e0173cf3ed1be2L40-R47) [[4]](diffhunk://#diff-9f2f4688660b09cb845faa7f555cc6473b0495a083af7bbfa7e0173cf3ed1be2R192) [[5]](diffhunk://#diff-9f2f4688660b09cb845faa7f555cc6473b0495a083af7bbfa7e0173cf3ed1be2R221)


closes #6 