### PR TITLE
fix(script): add test plan parameter to load test command

### DIFF
--- a/infra/scripts/setup-load-test.sh
+++ b/infra/scripts/setup-load-test.sh
@@ -81,7 +81,8 @@ if az load test show --load-test-resource "$LOAD_TEST_RESOURCE" --resource-group
         --test-id "$TEST_ID" \
         --display-name "SRE Agent Load Test" \
         --description "Automated load test for SRE Agent demo - simulates user traffic with random button clicks" \
-        --engine-instances "$ENGINE_INSTANCES"
+        --engine-instances "$ENGINE_INSTANCES" \
+        --test-plan "$TEMP_JMX"
 else
     az load test create \
         --load-test-resource "$LOAD_TEST_RESOURCE" \


### PR DESCRIPTION
This pull request introduces a small update to the load test setup script. The change adds the ability to specify a custom test plan file when running the Azure load test command.

* Load test configuration: The `az load test show` command now includes the `--test-plan "$TEMP_JMX"` option, allowing users to provide a custom JMX test plan file for more flexible and detailed load testing.