### PR TITLE
feat(alerts): add Azure Monitor alerts for HTTP 5xx errors

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -39,6 +39,12 @@
     "enableLoadTesting": {
       "value": true
     },
+    "enableMonitorAlerts": {
+      "value": true
+    },
+    "http5xxErrorThreshold": {
+      "value": 10
+    },
     "chaosExperimentDuration": {
       "value": "PT10M"
     },

--- a/infra/modules/azure-monitor-alert.bicep
+++ b/infra/modules/azure-monitor-alert.bicep
@@ -1,0 +1,95 @@
+// Azure Monitor Alert Module
+// Deploys metric alerts for App Service monitoring to trigger SRE Agent
+
+@description('Required. Name prefix for resources.')
+param namePrefix string
+
+@description('Optional. Location for all resources.')
+param location string = 'global'
+
+@description('Optional. Tags for all resources.')
+param tags object = {}
+
+@description('Required. Resource ID of the App Service to monitor.')
+param appServiceResourceId string
+
+@description('Optional. Enable Azure Monitor alerts.')
+param enableMonitorAlerts bool = true
+
+@description('Optional. Threshold for 5xx error count to trigger alert.')
+@minValue(1)
+param http5xxErrorThreshold int = 10
+
+@description('Optional. Evaluation frequency for the alert (ISO 8601 duration).')
+@allowed([
+  'PT1M'
+  'PT5M'
+  'PT15M'
+  'PT30M'
+  'PT1H'
+])
+param evaluationFrequency string = 'PT5M'
+
+@description('Optional. Window size for the alert evaluation (ISO 8601 duration).')
+@allowed([
+  'PT1M'
+  'PT5M'
+  'PT15M'
+  'PT30M'
+  'PT1H'
+  'PT6H'
+  'PT12H'
+  'P1D'
+])
+param windowSize string = 'PT5M'
+
+@description('Optional. Severity of the alert (0=Critical, 1=Error, 2=Warning, 3=Informational, 4=Verbose).')
+@allowed([0, 1, 2, 3, 4])
+param alertSeverity int = 0
+
+// Variables
+var alertName = 'alert-${namePrefix}-http5xx'
+var alertDescription = 'Alert triggered when HTTP 5xx server errors exceed threshold. This alert is designed to wake up SRE Agent for automatic incident investigation.'
+
+// Metric Alert for HTTP 5xx errors using AVM module
+module http5xxAlert 'br/public:avm/res/insights/metric-alert:0.3.1' = if (enableMonitorAlerts) {
+  name: '${uniqueString(deployment().name, location)}-http5xx-alert'
+  params: {
+    name: alertName
+    location: location
+    tags: union(tags, {
+      'sre-agent-alert': 'true'
+      'alert-type': 'http-5xx-errors'
+    })
+    alertDescription: alertDescription
+    severity: alertSeverity
+    enabled: true
+    scopes: [
+      appServiceResourceId
+    ]
+    evaluationFrequency: evaluationFrequency
+    windowSize: windowSize
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allof: [
+        {
+          name: 'Http5xxErrorCount'
+          criterionType: 'StaticThresholdCriterion'
+          metricName: 'Http5xx'
+          metricNamespace: 'Microsoft.Web/sites'
+          operator: 'GreaterThanOrEqual'
+          threshold: http5xxErrorThreshold
+          timeAggregation: 'Total'
+          dimensions: []
+        }
+      ]
+    }
+  }
+}
+
+// Outputs
+@description('The resource ID of the HTTP 5xx alert.')
+output http5xxAlertId string = enableMonitorAlerts ? http5xxAlert!.outputs.resourceId : ''
+
+@description('The name of the HTTP 5xx alert.')
+output http5xxAlertName string = enableMonitorAlerts ? http5xxAlert!.outputs.name : ''


### PR DESCRIPTION
This pull request introduces Azure Monitor alerting for HTTP 5xx errors in the App Service to support automated SRE Agent incident response. The main changes add new parameters for enabling and configuring alerts, integrate a new alert module into the deployment, and expose alert outputs for downstream use.

**Azure Monitor Alerting Integration**

* Added new parameters to `infra/main.bicep` for enabling monitor alerts and setting the HTTP 5xx error threshold, making alert configuration flexible at deployment time. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R64-R70) [[2]](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13R42-R47)
* Created a new module `infra/modules/azure-monitor-alert.bicep` to deploy metric alerts for App Service monitoring, including configuration for severity, evaluation frequency, and window size.
* Integrated the new alert module into the main Bicep deployment, passing necessary parameters and linking it to the App Service resource.

**Outputs and Resource Exposure**

* Added outputs for the alert resource ID and name to `infra/main.bicep`, making them available for other modules or post-deployment instructions.